### PR TITLE
Minimal implentation to ignore listed annotations

### DIFF
--- a/eval/eval.py
+++ b/eval/eval.py
@@ -577,7 +577,7 @@ GCtoIEC = {
 # to avoid magic numbers
 NO_RESULTS = -1.0
 
-GCSKIPCODES = frozenset(("E001", "C005", "Z002", "W001"))
+GCSKIPCODES = frozenset(("E001")
 
 # Define the command line arguments
 
@@ -1957,7 +1957,7 @@ def process(fpath_and_category: Tuple[str, str]) -> Dict[str, Any]:
                             xtok = None
                             xtok = next(x)
                             continue
-                        if ytok.code in GCSKIPCODES or ytok.code.endswith("/w"):
+                        if ytok.code in GCSKIPCODES:
                             # Skip these errors, shouldn't be compared.
                             if ANALYSIS:
                                 analysisblob.append(
@@ -2037,7 +2037,7 @@ def process(fpath_and_category: Tuple[str, str]) -> Dict[str, Any]:
                     analysisblob.append("\tDumping rest of GC errors:")
                 while ytok is not None:
                     # This is a remaining GC annotation: false positive
-                    if ytok.code in GCSKIPCODES or ytok.code.endswith("/w"):
+                    if ytok.code in GCSKIPCODES:
                         # Skip these errors, shouldn't be a part of the results.
                         if ANALYSIS:
                             analysisblob.append(

--- a/eval/eval.py
+++ b/eval/eval.py
@@ -577,7 +577,7 @@ GCtoIEC = {
 # to avoid magic numbers
 NO_RESULTS = -1.0
 
-GCSKIPCODES = frozenset(("E001")
+GCSKIPCODES = frozenset(["E001"])
 
 # Define the command line arguments
 
@@ -1275,22 +1275,25 @@ class Stats:
                             freq = cast(int, et["freq"])
                             fscore = cast(float, et["f05score"])
                             # codework
-                            subblob = subblob + "\t\t{} {}  ({:3.2f}, {:3.2f}, {:3.2f}) ({},{},{})| {}\n".format(
-                                code,
-                                freq,
-                                cast(float, et["recall"]) * 100.0
-                                if "recall" in et
-                                else 0.0,
-                                cast(float, et["precision"]) * 100.0
-                                if "precision" in et
-                                else 0.0,
-                                fscore * 100.0,
-                                cast(int, et["tp"]) if "tp" in et else 0,
-                                cast(int, et["fn"]) if "fn" in et else 0,
-                                cast(int, et["fp"]) if "fp" in et else 0,
-                                cast(float, et["corr_rec"])
-                                if "corr_rec" in et
-                                else 0.0,
+                            subblob = (
+                                subblob
+                                + "\t\t{} {}  ({:3.2f}, {:3.2f}, {:3.2f}) ({},{},{})| {}\n".format(
+                                    code,
+                                    freq,
+                                    cast(float, et["recall"]) * 100.0
+                                    if "recall" in et
+                                    else 0.0,
+                                    cast(float, et["precision"]) * 100.0
+                                    if "precision" in et
+                                    else 0.0,
+                                    fscore * 100.0,
+                                    cast(int, et["tp"]) if "tp" in et else 0,
+                                    cast(int, et["fn"]) if "fn" in et else 0,
+                                    cast(int, et["fp"]) if "fp" in et else 0,
+                                    cast(float, et["corr_rec"])
+                                    if "corr_rec" in et
+                                    else 0.0,
+                                )
                             )
                             # subwork
                             subfreq += freq
@@ -1385,31 +1388,38 @@ class Stats:
                             fscore = cast(float, et["f05score"])
                             cfscore = cast(float, et["cf05score"])
                             # codework
-                            subblob = subblob + "{}\t{}\t{}\t{}\t{}\t{:3.2f}\t{:3.2f}\t{:3.2f}\t{}\t{}\t{}\t{:3.2f}\t{:3.2f}\t{:3.2f}\n".format(
-                                code,
-                                freq,
-                                cast(int, et["tp"]) if "tp" in et else 0,
-                                cast(int, et["fn"]) if "fn" in et else 0,
-                                cast(int, et["fp"]) if "fp" in et else 0,
-                                cast(float, et["recall"]) * 100.0
-                                if ("recall" in et and float(et["recall"]) > 0.0)
-                                else NO_RESULTS,  # Or "N/A", but that messes with the f-string formatting
-                                cast(float, et["precision"]) * 100.0
-                                if ("precision" in et and float(et["precision"]) > 0.0)
-                                else NO_RESULTS,
-                                fscore * 100.0 if fscore > 0.0 else NO_RESULTS,
-                                cast(int, et["ctp"]) if "ctp" in et else 0,
-                                cast(int, et["cfn"]) if "cfn" in et else 0,
-                                cast(int, et["cfp"]) if "cfp" in et else 0,
-                                cast(float, et["crecall"]) * 100.0
-                                if ("crecall" in et and float(et["crecall"]) > 0.0)
-                                else NO_RESULTS,
-                                cast(float, et["cprecision"]) * 100.0
-                                if (
-                                    "cprecision" in et and float(et["cprecision"]) > 0.0
+                            subblob = (
+                                subblob
+                                + "{}\t{}\t{}\t{}\t{}\t{:3.2f}\t{:3.2f}\t{:3.2f}\t{}\t{}\t{}\t{:3.2f}\t{:3.2f}\t{:3.2f}\n".format(
+                                    code,
+                                    freq,
+                                    cast(int, et["tp"]) if "tp" in et else 0,
+                                    cast(int, et["fn"]) if "fn" in et else 0,
+                                    cast(int, et["fp"]) if "fp" in et else 0,
+                                    cast(float, et["recall"]) * 100.0
+                                    if ("recall" in et and float(et["recall"]) > 0.0)
+                                    else NO_RESULTS,  # Or "N/A", but that messes with the f-string formatting
+                                    cast(float, et["precision"]) * 100.0
+                                    if (
+                                        "precision" in et
+                                        and float(et["precision"]) > 0.0
+                                    )
+                                    else NO_RESULTS,
+                                    fscore * 100.0 if fscore > 0.0 else NO_RESULTS,
+                                    cast(int, et["ctp"]) if "ctp" in et else 0,
+                                    cast(int, et["cfn"]) if "cfn" in et else 0,
+                                    cast(int, et["cfp"]) if "cfp" in et else 0,
+                                    cast(float, et["crecall"]) * 100.0
+                                    if ("crecall" in et and float(et["crecall"]) > 0.0)
+                                    else NO_RESULTS,
+                                    cast(float, et["cprecision"]) * 100.0
+                                    if (
+                                        "cprecision" in et
+                                        and float(et["cprecision"]) > 0.0
+                                    )
+                                    else NO_RESULTS,
+                                    cfscore * 100.0 if cfscore > 0.0 else NO_RESULTS,
                                 )
-                                else NO_RESULTS,
-                                cfscore * 100.0 if cfscore > 0.0 else NO_RESULTS,
                             )
                             # subwork
                             subfreq += freq

--- a/src/reynir_correct/checker.py
+++ b/src/reynir_correct/checker.py
@@ -49,6 +49,7 @@
 
 from typing import (
     Any,
+    FrozenSet,
     Mapping,
     cast,
     Iterable,
@@ -189,7 +190,7 @@ class GreynirCorrect(Greynir):
         self._annotate_unparsed_sentences = options.pop(
             "annotate_unparsed_sentences", True
         )
-        self._ignore_rules = options.get("ignore_rules", [])
+        self._ignore_rules: FrozenSet[str] = options.get("ignore_rules", set())
         super().__init__(**options)
         self._options = options
         # if options:
@@ -382,12 +383,7 @@ class GreynirCorrect(Greynir):
                 # Check the next pair
                 i += 1
         # Remove ignored annotations
-        i = 0
-        while i < len(ann):
-            if ann[i].code in self._ignore_rules:
-                del ann[i]
-            else:
-                i += 1
+        ann = [a for a in ann if a.code not in self._ignore_rules]
         return ann
 
     def create_sentence(self, job: Job, s: TokenList) -> Sentence:

--- a/src/reynir_correct/checker.py
+++ b/src/reynir_correct/checker.py
@@ -189,7 +189,7 @@ class GreynirCorrect(Greynir):
         self._annotate_unparsed_sentences = options.pop(
             "annotate_unparsed_sentences", True
         )
-        self._ignore_rules = options.pop("ignore_rules", [])
+        self._ignore_rules = options.get("ignore_rules", [])
         super().__init__(**options)
         self._options = options
         # if options:
@@ -316,7 +316,11 @@ class GreynirCorrect(Greynir):
                     ann.append(a)
         # Then, look at the whole sentence
         num_words = words_in_bin + words_not_in_bin
-        if num_words > 2 and words_in_bin / num_words < ICELANDIC_RATIO:
+        if (
+            num_words > 2
+            and words_in_bin / num_words < ICELANDIC_RATIO
+            and "E004" not in self._ignore_rules
+        ):
             # The sentence contains less than 50% Icelandic
             # words: assume it's in a foreign language and discard the
             # token level annotations
@@ -333,7 +337,7 @@ class GreynirCorrect(Greynir):
                 )
             ]
         elif not parsed:
-            if self._annotate_unparsed_sentences:
+            if self._annotate_unparsed_sentences and "E001" not in self._ignore_rules:
                 # If the sentence couldn't be parsed,
                 # put an annotation on it as a whole.
                 # In this case, we keep the token-level annotations.

--- a/src/reynir_correct/checker.py
+++ b/src/reynir_correct/checker.py
@@ -189,6 +189,7 @@ class GreynirCorrect(Greynir):
         self._annotate_unparsed_sentences = options.pop(
             "annotate_unparsed_sentences", True
         )
+        self._ignore_rules = options.pop("ignore_rules", [])
         super().__init__(**options)
         self._options = options
         # if options:
@@ -375,6 +376,13 @@ class GreynirCorrect(Greynir):
                 del ann[i]
             else:
                 # Check the next pair
+                i += 1
+        # Remove ignored annotations
+        i = 0
+        while i < len(ann):
+            if ann[i].code in self._ignore_rules:
+                del ann[i]
+            else:
                 i += 1
         return ann
 

--- a/src/reynir_correct/errtokenizer.py
+++ b/src/reynir_correct/errtokenizer.py
@@ -1503,6 +1503,10 @@ class MultiwordErrorStream(MatchingStream):
     def match(self, tq: List[Tok], ix: int) -> Iterable[Tok]:
         """This is a complete match of an error phrase;
         yield the replacement phrase"""
+        if "P_" + MultiwordErrors.get_code(ix) in self._ignore_rules:
+            for t in tq:
+                yield t
+            return
         replacement = MultiwordErrors.get_replacement(ix)
         db = self._db
         token_ctor = self._token_ctor
@@ -1532,7 +1536,7 @@ class MultiwordErrorStream(MatchingStream):
             if capfirst:
                 repstring = repstring.capitalize()
                 capfirst = False
-            if i == 0 and MultiwordErrors.get_code((ix)) not in self._ignore_rules:
+            if i == 0:
                 ct.set_error(
                     PhraseError(
                         MultiwordErrors.get_code(ix),

--- a/src/reynir_correct/errtokenizer.py
+++ b/src/reynir_correct/errtokenizer.py
@@ -2595,7 +2595,8 @@ def late_fix_capitalization(
             at_sentence_start = True
             continue
         if (
-            token.error_code
+            isinstance(token, CorrectToken)
+            and token.error_code
             and token.error_code == "Z002"
             and " " in token.txt
             and token.original
@@ -2742,8 +2743,10 @@ def late_fix_merges(
                     ),
                 )
         elif (
-            token.error
+            isinstance(token, CorrectToken)  # type: ignore
+            and token.error
             and " " in token.txt
+            and token.error_suggest
             and not " " in token.error_suggest
             and token.original
         ):

--- a/src/reynir_correct/errtokenizer.py
+++ b/src/reynir_correct/errtokenizer.py
@@ -2598,6 +2598,7 @@ def late_fix_capitalization(
             token.error_code
             and token.error_code == "Z002"
             and " " in token.txt
+            and token.original
             and not " " in token.error_original
         ):
             # Error was not updated when the compound was amalgamated
@@ -2740,7 +2741,12 @@ def late_fix_merges(
                         suggest=token.txt,
                     ),
                 )
-        elif token.error and " " in token.txt and not " " in token.error_suggest:
+        elif (
+            token.error
+            and " " in token.txt
+            and not " " in token.error_suggest
+            and token.original
+        ):
             # Error was added to the token before merging with another (fimm milljónir *kóna*)
             # Capitalization errors are handled elsewhere, most likely spelling errors here
             # Determine which word(s) in the string the error represents

--- a/src/reynir_correct/tools/diffchecker.py
+++ b/src/reynir_correct/tools/diffchecker.py
@@ -42,19 +42,19 @@ def gen(f: Iterator[str]) -> Iterable[str]:
 def main() -> None:
 
     options: Dict[str, Union[str, bool, Set[str]]] = {}
-    # Hægt að biðja um annað til að fá frekari upplýsingar!
     options["format"] = "text"  # text, json, csv, m2
     options["annotations"] = True
     options["all_errors"] = True
     # options["infile"] = open("prufa.txt", "r")
     options["one_sent"] = False
     # options["generate_suggestion_list"] = True
-    options["ignore_comments"] = True  # Only used here
+    options["ignore_comments"] = False  # Only used here
+    options["generate_suggestion_list"] = False
     options["annotate_unparsed_sentences"] = True
     options["ignore_wordlist"] = set()
     options["spaced"] = False
     options["print_all"] = True
-    options["ignore_rules"] = {"C002"}
+    options["ignore_rules"] = set("")
     args = parser.parse_args()
     inputfile = args.inputfile
     if inputfile is sys.stdin and sys.stdin.isatty():

--- a/src/reynir_correct/tools/diffchecker.py
+++ b/src/reynir_correct/tools/diffchecker.py
@@ -54,7 +54,7 @@ def main() -> None:
     options["ignore_wordlist"] = set()
     options["spaced"] = False
     options["print_all"] = True
-    options["ignore_rules"] = set("")
+    options["ignore_rules"] = set([""])
     args = parser.parse_args()
     inputfile = args.inputfile
     if inputfile is sys.stdin and sys.stdin.isatty():

--- a/src/reynir_correct/tools/diffchecker.py
+++ b/src/reynir_correct/tools/diffchecker.py
@@ -54,6 +54,7 @@ def main() -> None:
     options["ignore_wordlist"] = set()
     options["spaced"] = False
     options["print_all"] = True
+    # options["ignore_rules"] = {"EI4EY", "S001", "P_NT_Einkunn", "C004/w", "P_NT_Heldur/w"}
     args = parser.parse_args()
     inputfile = args.inputfile
     if inputfile is sys.stdin and sys.stdin.isatty():

--- a/src/reynir_correct/tools/diffchecker.py
+++ b/src/reynir_correct/tools/diffchecker.py
@@ -54,7 +54,7 @@ def main() -> None:
     options["ignore_wordlist"] = set()
     options["spaced"] = False
     options["print_all"] = True
-    # options["ignore_rules"] = {"EI4EY", "S001", "P_NT_Einkunn", "C004/w", "P_NT_Heldur/w"}
+    options["ignore_rules"] = {"C002"}
     args = parser.parse_args()
     inputfile = args.inputfile
     if inputfile is sys.stdin and sys.stdin.isatty():

--- a/src/reynir_correct/tools/diffchecker.py
+++ b/src/reynir_correct/tools/diffchecker.py
@@ -54,7 +54,7 @@ def main() -> None:
     options["ignore_wordlist"] = set()
     options["spaced"] = False
     options["print_all"] = True
-    options["ignore_rules"] = set([""])
+    options["ignore_rules"] = set()
     args = parser.parse_args()
     inputfile = args.inputfile
     if inputfile is sys.stdin and sys.stdin.isatty():

--- a/src/reynir_correct/wrappers.py
+++ b/src/reynir_correct/wrappers.py
@@ -318,7 +318,7 @@ def test_grammar(**options: Any) -> Tuple[str, TokenSumType]:
     inneroptions["annotate_unparsed_sentences"] = options.get(
         "annotate_unparsed_sentences", True
     )
-    inneroptions["ignore_rules"] = options.get("ignore_rules", [])
+    inneroptions["ignore_rules"] = options.get("ignore_rules", set())
     annlist: List[str] = []
     for toklist in sentence_stream(**options):
         # Invoke the spelling and grammar checker on the token list
@@ -381,7 +381,7 @@ def check_grammar(**options: Any) -> str:
     inneroptions["annotate_unparsed_sentences"] = options.get(
         "annotate_unparsed_sentences", True
     )
-    inneroptions["ignore_rules"] = options.get("ignore_rules", [])
+    inneroptions["ignore_rules"] = options.get("ignore_rules", set())
     annlist: List[str] = []
     format = options.get("format", "")
     for toklist in sentence_stream(**options):

--- a/src/reynir_correct/wrappers.py
+++ b/src/reynir_correct/wrappers.py
@@ -318,6 +318,7 @@ def test_grammar(**options: Any) -> Tuple[str, TokenSumType]:
     inneroptions["annotate_unparsed_sentences"] = options.get(
         "annotate_unparsed_sentences", True
     )
+    inneroptions["ignore_rules"] = options.get("ignore_rules", [])
     annlist: List[str] = []
     for toklist in sentence_stream(**options):
         # Invoke the spelling and grammar checker on the token list
@@ -380,6 +381,7 @@ def check_grammar(**options: Any) -> str:
     inneroptions["annotate_unparsed_sentences"] = options.get(
         "annotate_unparsed_sentences", True
     )
+    inneroptions["ignore_rules"] = options.get("ignore_rules", [])
     annlist: List[str] = []
     format = options.get("format", "")
     for toklist in sentence_stream(**options):

--- a/test/test_allkinds.py
+++ b/test/test_allkinds.py
@@ -59,10 +59,7 @@ def normalize(g):
 
 def check(p):
     """Return a corrected, normalized string form of the input along with the tokens"""
-    options = {}
-    options["infile"] = [p]
-    options["one_sent"] = False
-
+    options = dict(infile=[p], one_sent=False)
     return check_errors(**options)
 
 
@@ -1545,10 +1542,11 @@ def test_né():
 def test_ignore_rules(verbose=False):
     options = {}
     options["ignore_rules"] = {"C001"}
-    # doubling
+    # doubling - C001
     s, g = check_with_options("Ég hélt mér mér fast í sætið.", options)
     assert not g[3].error_code
-    # wrong compounds
+
+    # wrong compounds - C002
     options["ignore_rules"] = {"C002"}
     s, g = check_with_options(
         "Fötin koma í margskonar litum og fara afturábak afþvíað annarstaðar "
@@ -1558,6 +1556,7 @@ def test_ignore_rules(verbose=False):
     for ix in range(len(g)):
         # Setningin þáttast ekki fyrst villurnar finnast ekki
         assert not g[ix].error_code or g[ix].error_code in {"E001"}
+
     # split compounds
     options["ignore_rules"] = {"C003", "C005/w"}
     s, g = check_with_options(
@@ -1565,6 +1564,7 @@ def test_ignore_rules(verbose=False):
     )
     for ix in range(len(g)):
         assert not g[ix].error_code or g[ix].error_code in {"E001"}
+
     # unique_context_independent_errors
     options["ignore_rules"] = {
         "S001",
@@ -1599,6 +1599,124 @@ def test_ignore_rules(verbose=False):
     # Pattern errors
     options["ignore_rules"] = {"P_NT_Heldur"}
     s, g = check_with_options("Gíraffi er stærri heldur en fíll.", options)
+    for ix in range(len(g)):
+        assert not g[ix].error_code or g[ix].error_code in {"E001"}
+
+    # check_style - Y001/w
+    options["ignore_rules"] = {"Y001/w"}
+    s, g = check_with_options("Hún er æxling og labbaði um herbergið.", options)
+    for ix in range(len(g)):
+        assert not g[ix].error_code or g[ix].error_code in {"E001"}
+
+    # check_taboo_words - T001/w
+    options["ignore_rules"] = {"T001/w"}
+    s, g = check_with_options("Hann er typpalingur og labbaði um herbergið.", options)
+    for ix in range(len(g)):
+        assert not g[ix].error_code or g[ix].error_code in {"E001"}
+
+    # late_fix_merges - S005
+    options["ignore_rules"] = {"S005"}
+    s, g = check_with_options(
+        "Hún á fimm miljónir króna og labbaði um herbergið.", options
+    )
+    for ix in range(len(g)):
+        assert not g[ix].error_code or g[ix].error_code in {"E001"}
+    s, g = check_with_options(
+        "Það er 1,8 millarður króna sem labbaði um herbergið.", options
+    )
+    for ix in range(len(g)):
+        assert not g[ix].error_code or g[ix].error_code in {"E001"}
+
+    # late_fix_capitalization
+    # Z001
+    options["ignore_rules"] = {"Z001"}
+    s, g = check_with_options(
+        "Hann var Félags- og barnamálaráðherra og labbaði um herbergið.", options
+    )
+    for ix in range(len(g)):
+        assert not g[ix].error_code or g[ix].error_code in {"E001", "S005"}
+
+    # Z002
+    options["ignore_rules"] = {"Z002"}
+    s, g = check_with_options(
+        "félags- og barnamálaráðherra labbaði um herbergið.", options
+    )
+    for ix in range(len(g)):
+        assert not g[ix].error_code or g[ix].error_code in {"E001", "S005"}
+
+    # Z004
+    options["ignore_rules"] = {"Z004"}
+    s, g = check_with_options("500 Milljónir löbbuðu um herbergið.", options)
+    for ix in range(len(g)):
+        assert not g[ix].error_code or g[ix].error_code in {"E001"}
+
+    # Z005
+    options["ignore_rules"] = {"Z005"}
+    s, g = check_with_options("Fimm Hundruð milljónir löbbuðu um herbergið.", options)
+    for ix in range(len(g)):
+        assert not g[ix].error_code or g[ix].error_code in {"E001"}
+
+    # fix_capitalization
+    # Z002
+    options["ignore_rules"] = {"Z002"}
+    s, g = check_with_options(
+        "Hún heitir hrafnhildur benediktsdóttir og labbaði um herbergið.", options
+    )
+    for ix in range(len(g)):
+        assert not g[ix].error_code or g[ix].error_code in {"E001", "U001"}
+    s, g = check_with_options(
+        "Hann heitir ásþór harðarson og labbaði um herbergið.", options
+    )
+    for ix in range(len(g)):
+        assert not g[ix].error_code or g[ix].error_code in {"E001", "U001"}
+
+    # Z006
+    options["ignore_rules"] = {"Z006"}
+    s, g = check_with_options("Hann var í Así og labbaði um herbergið.", options)
+    for ix in range(len(g)):
+        assert not g[ix].error_code or g[ix].error_code in {"E001", "S004"}
+
+    # Z003
+    options["ignore_rules"] = {"Z003"}
+    s, g = check_with_options("Hann datt 15. Apríl og labbaði um herbergið.", options)
+    for ix in range(len(g)):
+        assert not g[ix].error_code or g[ix].error_code in {"E001"}
+
+    # lookup_unknown_wors
+    # Ritmyndir errors - EI4EY
+    options["ignore_rules"] = {"EI4EY"}
+    s, g = check_with_options("Gíraffi er stærri heldur en fíll.", options)
+    for ix in range(len(g)):
+        assert not g[ix].error_code or g[ix].error_code in {"E001"}
+
+    # S001 - Icelandic error corpus nonwords
+    options["ignore_rules"] = {"S001"}
+    s, g = check_with_options(
+        "Hann á þriðjun í starfsemi og labbaði um herbergið.", options
+    )
+    for ix in range(len(g)):
+        assert not g[ix].error_code or g[ix].error_code in {"E001"}
+
+    # S002 - CIDErrorForms
+    options["ignore_rules"] = {"S002"}
+    s, g = check_with_options(
+        "Hann saknar aðalspurningunnar og labbaði um herbergið.", options
+    )
+    for ix in range(len(g)):
+        assert not g[ix].error_code or g[ix].error_code in {"E001"}
+
+    # U001
+    options["ignore_rules"] = {"U001"}
+    s, g = check_with_options("Hún er blurbilosiru og labbaði um herbergið.", options)
+    for ix in range(len(g)):
+        assert not g[ix].error_code or g[ix].error_code in {"E001"}
+
+    # C006
+    options["ignore_rules"] = {"C006"}
+    s, g = check_with_options("Hún var kvennmaður og labbaði um herbergið.", options)
+    for ix in range(len(g)):
+        assert not g[ix].error_code or g[ix].error_code in {"E001", "NN4N-ORD"}
+    s, g = check_with_options("Hann var feyknaglaður og labbaði um herbergið.", options)
     for ix in range(len(g)):
         assert not g[ix].error_code or g[ix].error_code in {"E001"}
 

--- a/test/test_allkinds.py
+++ b/test/test_allkinds.py
@@ -1540,6 +1540,7 @@ def test_né():
 
 
 def test_ignore_rules(verbose=False):
+    """Test error annotation deletion. In some cases, when a certain error type is skipped, another similar error type is applied."""
     options = {}
     options["ignore_rules"] = {"C001"}
     # doubling - C001


### PR DESCRIPTION
This is a minimally functional implementation to ignore annotations by rule name.

This works by removing the annotations right at the end of the process before they're returned to the user.

This works well for corrections that do not modify the token text and only provide a suggestion for a fix. For corrections that modify the text directly, e.g. spelling corrections, this removes the annotation but does not undo the modification. That seems to be much more complicated since the modifications are made in different places. Needs some thought.