### PR TITLE
README updated; check_errors() made available from command line

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,69 @@ annotation applies, within the original input string.
 
 ``P_WRONG_CASE_þgf_þf`` and ``S004`` are error codes.
 
+Another function supports options and corrects the output:
+
+.. code-block:: python
+   from reynir_correct import check_errors
+   x = "Páli, vini mínum, langaði að horfa á sjónnvarpið."
+   options = {}
+   options["infile"] = [x]
+   options["annotations"] = True
+   s, g = check_errors(**options)
+   print("Original sentence:")
+   print("".join([p.original for p in g if p.original]))
+   print("Corrected sentence and annotations:")
+   for i in split("\n"):
+      print(i)
+
+Output::
+
+   Original sentence:
+   'Páli, vini mínum, langaði að horfa á sjónnvarpið.'
+   Corrected sentence and annotations:
+   'Pál, vin minn, langaði að horfa á sjónvarpið.'
+   000-004: P_WRONG_CASE_þgf_þf Á líklega að vera 'Pál, vin minn' | 'Páli, vini mínum,' -> 'Pál, vin minn' | None
+   009-009: S004   Orðið 'sjónnvarpið' var leiðrétt í 'sjónvarpið' | 'sjónnvarpið' -> 'sjónvarpið' | None
+
+
+The following options can be specified:
+
+
++-----------------------------------+--------------------------------------------------+
+| | ``infile``                      | Defines the input. Can be a ReadFile             |
+|                                   | object or an Iterable object such as             |
+|                                   | a generator. Default value is sys.stdin.         |
++-----------------------------------+--------------------------------------------------+
+| | ``all_errors``                  | Defines the level of correction.                 |
+|                                   | If False, only token-level annotation is         |
+|                                   | carried out. If True, sentence-level             |
+|                                   | annotation is carried out.                       |
++-----------------------------------+--------------------------------------------------+
+| | ``annotate_unparsed_sentences`` | If True, sentences that cannot be parsed         |
+|                                   | are annotated as errors as a whole.              |
++-----------------------------------+--------------------------------------------------+
+| | ``generate_suggestion_list``    | If True, the annotation can in certain           |
+|                                   | cases contain a list of possible corrections,    |
+|                                   | for the user to pick from.                       |
++-----------------------------------+--------------------------------------------------+
+| | ``suppress_suggestions``        | If True, more farfetched automatically           |
+|                                   | retrieved corrections are rejected and           |
+|                                   | no error is added.                               |
++-----------------------------------+--------------------------------------------------+
+| | ``ignore_wordlist``             | The value is a set of strings, a whitelist.      |
+|                                   | Each string is a word that should not be         |
+|                                   | marked as an error or corrected.                 |
++-----------------------------------+--------------------------------------------------+
+| | ``one_sent``                    | Defines input as containing only one sentence.   |
++-----------------------------------+--------------------------------------------------+
+| | ``ignore_rules``                | A list of error codes that should be ignored     |
+|                                   | in the annotation process.                       |
++-----------------------------------+--------------------------------------------------+
+| | ``annotations``                 | If True, can all error annotations are returned  |
+|                                   | at the end of the output. Works with format text.|
++-----------------------------------+--------------------------------------------------+
+
+
 .. _prerequisites:
 
 *************

--- a/src/reynir_correct/__init__.py
+++ b/src/reynir_correct/__init__.py
@@ -51,12 +51,14 @@ from .checker import (
     AnnotatedSentence,
 )
 
+from .wrappers import check_errors
+
 # Annotations
 from .annotation import Annotation
 
 from .version import __version__
 
-__author__ = u"Miðeind ehf"
+__author__ = "Miðeind ehf"
 __copyright__ = "(C) 2022 Miðeind ehf."
 
 __all__ = (
@@ -75,6 +77,7 @@ __all__ = (
     "check_single",
     "check_with_stats",
     "check_with_custom_parser",
+    "check_errors",
     "AnnotatedSentence",
     "Annotation",
     "__version__",

--- a/src/reynir_correct/wrappers.py
+++ b/src/reynir_correct/wrappers.py
@@ -192,7 +192,7 @@ def check_errors(**options: Any) -> str:
         # Nothing we can do
         print("No input has been given, nothing can be returned")
         sys.exit(1)
-    if options.get("all_errors"):
+    if options.get("all_errors", True):
         return check_grammar(**options)
     else:
         return check_spelling(**options)

--- a/test/test_allkinds.py
+++ b/test/test_allkinds.py
@@ -1683,7 +1683,7 @@ def test_ignore_rules(verbose=False):
     for ix in range(len(g)):
         assert not g[ix].error_code or g[ix].error_code in {"E001"}
 
-    # lookup_unknown_wors
+    # lookup_unknown_words
     # Ritmyndir errors - EI4EY
     options["ignore_rules"] = {"EI4EY"}
     s, g = check_with_options("Gíraffi er stærri heldur en fíll.", options)


### PR DESCRIPTION
* New options are now detailed in the README
* check_errors() is now available from command line**


** For some reason I can't get this to work. I can get the following to work in the command line, and the function check_with_options basically does what is detailed in the README, so I see no obvious reason why the underlying function can't be used in the command line.

`>>> from test_allkinds import check_with_options
>>> x = "Páli, vini mínum, langaði að horfa á sjónnvarpið."
>>> options = {}
>>> options["infile"] = [x]
>>> s, g = check_with_options(x, options)
>>> "".join([p.original for p in g if p.original])
'Páli, vini mínum, langaði að horfa á sjónnvarpið.'
>>> s
'Pál, vin minn langaði að horfa á sjónvarpið.'
>>> options["annotations"] = True
>>> s, g = check_with_options(x, options)
>>> s
"Pál, vin minn langaði að horfa á sjónvarpið.\n000-004: P_WRONG_CASE_þgf_þf Á líklega að vera 'Pál, vin minn' | 'Páli, vini mínum,' -> 'Pál, vin minn' | None\n009-009: S004   Orðið 'sjónnvarpið' var leiðrétt í 'sjónvarpið' | 'sjónnvarpið' -> 'sjónvarpið' | None"
>>> for i in s.split("\n"):
...     print(i)
... 
Pál, vin minn langaði að horfa á sjónvarpið.
000-004: P_WRONG_CASE_þgf_þf Á líklega að vera 'Pál, vin minn' | 'Páli, vini mínum,' -> 'Pál, vin minn' | None
009-009: S004   Orðið 'sjónnvarpið' var leiðrétt í 'sjónvarpið' | 'sjónnvarpið' -> 'sjónvarpið' | None
`

