### PR TITLE
Rulefixes

### DIFF
--- a/src/reynir_correct/config/GreynirCorrect.conf
+++ b/src/reynir_correct/config/GreynirCorrect.conf
@@ -4819,7 +4819,7 @@ við líði                    	$error(IIYY, við lýði)
 í mestu kviðunum				$error(HVKV, í mestu hviðunum)
 í rénum                     	$error(WRONG_WORD, í rénun)
 í staðin                    	$error(WRONG_WORD, í staðinn)
-í takt við                  	$error(WRONG_CASE, í takti við)
+#í takt við                  	$error(WRONG_CASE, í takti við) # not explicitly an error
 í tilefni að                    $error(AÐAF, í tilefni af)
 í því skini						$error(IY, í því skyni)
 ítrustu varúðar             	$error(IIYY, ýtrustu varúðar)

--- a/src/reynir_correct/errtokenizer.py
+++ b/src/reynir_correct/errtokenizer.py
@@ -212,6 +212,9 @@ STOP_WORDS = frozenset(("in", "the", "for", "at"))
 
 RITREGLUR_URL = "https://ritreglur.arnastofnun.is/#"
 
+# The set contains two kinds of data
+# Single word forms: 'nýbúinn' should be excluded, but other word forms of 'nýbúi' should not
+# Lemmas_part-of-speech: all word forms of 'hommi' should be excluded from checking.
 NOT_TABOO = frozenset(("nýbúinn", "hommi_kk"))
 
 # A dictionary of token error classes, used in serialization
@@ -2663,7 +2666,7 @@ def late_fix_capitalization(
                                 suggest=correct,
                             )
                         )
-            if suppress_suggestions and token.error_code and token.error_code == "Z001" and isinstance(token.val, list) and any(v.ordfl == "lo" for v in token.val):  # type: ignore
+            if suppress_suggestions and token.error_code == "Z001" and isinstance(token.val, list) and any(v.ordfl == "lo" for v in token.val):  # type: ignore
                 orig = token.original.strip() if token.original else token.txt
                 token.remove_error(orig)
 
@@ -2882,7 +2885,7 @@ def check_taboo_words(token_stream: Iterable[CorrectToken]) -> Iterator[CorrectT
                         and token.txt.strip() != token.original.strip()
                     ):
                         # The system seems to have used automatic methods to 'correct'
-                        # to a taboo words: remove the error
+                        # to a taboo word: remove the error
                         orig = (
                             token.original.strip()
                             if token.original

--- a/src/reynir_correct/errtokenizer.py
+++ b/src/reynir_correct/errtokenizer.py
@@ -1926,6 +1926,9 @@ def lookup_unknown_words(
         if code in ignore_rules:
             return token
         corrected = Ritmyndir.get_correct_form(token.txt)
+        if token.txt[0].istitle() and not corrected.istitle():
+            # Most likely a (foreign) named entity - Sky News → Ský News
+            return token
         corrected = emulate_case(corrected, template=token.txt)
         if not corrected:
             # No correct value available

--- a/src/reynir_correct/errtokenizer.py
+++ b/src/reynir_correct/errtokenizer.py
@@ -2503,6 +2503,10 @@ def fix_capitalization(
                         v.ordfl == "lo" for v in token.val
                     ):
                         # Token is capitalized but should be lower case
+                        # NOTE: We skip checks for adjectives as they are in most cases a part of
+                        # a named entity (Danska ríkisútvarpið, Íslensk erfðagreining) that
+                        # the system does not recognize. In the case of better NER, this should
+                        # be reverted.
                         original_txt = token.txt
                         correct = token.txt.lower()
                         _, m = db.lookup_g(correct, False)

--- a/src/reynir_correct/errtokenizer.py
+++ b/src/reynir_correct/errtokenizer.py
@@ -2664,7 +2664,8 @@ def late_fix_capitalization(
                             )
                         )
             if suppress_suggestions and token.error_code and token.error_code == "Z001" and isinstance(token.val, list) and any(v.ordfl == "lo" for v in token.val):  # type: ignore
-                token.remove_error(token.original.strip())
+                orig = token.original.strip() if token.original else token.txt
+                token.remove_error(orig)
 
         elif token.kind == TOK.NUMBER:
             if re.match(r"[0-9.,/-]+$", token.txt) or token.txt.isupper():
@@ -2876,12 +2877,18 @@ def check_taboo_words(token_stream: Iterable[CorrectToken]) -> Iterator[CorrectT
                         sugglist = list(w.split("_")[0] for w in sw)
                     if (
                         token.error_code
+                        and token.original
                         and token.error_code[0] == "W"
                         and token.txt.strip() != token.original.strip()
                     ):
                         # The system seems to have used automatic methods to 'correct'
                         # to a taboo words: remove the error
-                        token.remove_error(token.original.strip())
+                        orig = (
+                            token.original.strip()
+                            if token.original
+                            else token.txt.strip()
+                        )
+                        token.remove_error(orig)
                     else:
                         token.set_error(
                             TabooWarning(

--- a/src/reynir_correct/errtokenizer.py
+++ b/src/reynir_correct/errtokenizer.py
@@ -2499,8 +2499,10 @@ def fix_capitalization(
                             )
                         )
                 else:
-                    if "Z001" not in ignore_rules and not any(
-                        v.ordfl == "lo" for v in token.val
+                    if (  # type: ignore
+                        "Z001" not in ignore_rules
+                        and isinstance(token.val, BIN_Tuple)
+                        and not any(v.ordfl == "lo" for v in token.val)  # type: ignore
                     ):
                         # Token is capitalized but should be lower case
                         # NOTE: We skip checks for adjectives as they are in most cases a part of
@@ -2826,10 +2828,12 @@ def check_taboo_words(token_stream: Iterable[CorrectToken]) -> Iterator[CorrectT
 
     for token in token_stream:
         # Check taboo words
-        if (
-            token.has_meanings
+        if (  # type: ignore
+            token.val is not None
+            and token.has_meanings
             and token.txt not in NOT_TABOO
-            and not any(v.stofn + "_" + v.ordfl for v in token.val)
+            and isinstance(token.val, BIN_Tuple)
+            and not any(v.stofn + "_" + v.ordfl for v in token.val)  # type: ignore
             and not token.error
         ):
             # We skip checks for tokens already containing an error, as the taboo word

--- a/src/reynir_correct/errtokenizer.py
+++ b/src/reynir_correct/errtokenizer.py
@@ -1929,7 +1929,9 @@ def lookup_unknown_words(
             return token
         corrected = Ritmyndir.get_correct_form(token.txt)
         if (
+            # Needed due to difference in title case for Icelandic and English in MWE
             token.txt[0].istitle()
+            and not token.txt.isupper()
             and not token.cap_sentence_start
             and not corrected.istitle()
         ):

--- a/src/reynir_correct/errtokenizer.py
+++ b/src/reynir_correct/errtokenizer.py
@@ -1926,7 +1926,13 @@ def lookup_unknown_words(
         if code in ignore_rules:
             return token
         corrected = Ritmyndir.get_correct_form(token.txt)
-        if token.txt[0].istitle() and not corrected.istitle():
+        if (
+            token.txt[0].istitle()
+            and not token.cap_sentence_start
+            and not corrected.istitle()
+        ):
+            # We only want to correct tokens in title case not at sentence start
+            # if the correction is also in title case
             # Most likely a (foreign) named entity - Sky News → Ský News
             return token
         corrected = emulate_case(corrected, template=token.txt)
@@ -2042,6 +2048,15 @@ def lookup_unknown_words(
         ):
             # Don't correct PCR-próf to Pcr-próf,
             # or félags- og barnamálaráðherra to félags- og varnamálaráðherra
+            return False
+        elif (
+            token.txt[0].isupper()
+            and not token.cap_sentence_start
+            and not any(is_cap(mean.stofn) for mean in m)
+        ):
+            # We only want to correct tokens in title case not at sentence start
+            #  if the correction appears in title case in the data,
+            # Most likely a (foreign) named entity - Sky News -> Ský News
             return False
         # elif len(token.txt) == 1 and (
         #    corrected_txt

--- a/src/reynir_correct/pattern.py
+++ b/src/reynir_correct/pattern.py
@@ -223,20 +223,20 @@ class PatternMatcher:
             vp = match.first_match("VP >> { %verb }", self.ctx_af)
         # Find the attached prepositional phrase
         pp = match.first_match('P > { "af" }')
-        # Calculate the start and end token indices, spanning both phrases
         if vp is None or pp is None:
             return
         pp_af = pp.first_match('"af"')
         if pp_af is None:
             return
-        start, end = min(vp.span[0], pp.span[0]), max(vp.span[1], pp.span[1])
+        # Calculate the start and end token indices, spanning both phrases
+        start, end = pp_af.span
         text = "'{0} af' á sennilega að vera '{0} að'".format(vp.tidy_text)
         detail = (
             "Sögnin '{0}' tekur yfirleitt með sér "
             "forsetninguna 'að', ekki 'af'.".format(vp.tidy_text)
         )
-        suggest = match.substituted_text(pp_af, "að")
-        if suggest == match.tidy_text:
+        suggest = pp_af.substituted_text(pp_af, "að")
+        if suggest == pp_af.tidy_text:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -246,7 +246,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AF",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_af.tidy_text,
                 suggest=suggest,
             )
         )
@@ -265,14 +265,14 @@ class PatternMatcher:
         pp_að = pp.first_match('"að"')
         if pp_að is None:
             return
-        start, end = min(vp.span[0], pp.span[0]), max(vp.span[1], pp.span[1])
+        start, end = pp_að.span
         text = "'{0} að' á sennilega að vera '{0} af'".format(vp.tidy_text)
         detail = (
             "Sögnin '{0}' tekur yfirleitt með sér "
             "forsetninguna 'af', ekki 'að'.".format(vp.tidy_text)
         )
-        suggest = match.substituted_text(pp_að, "af")
-        if suggest == match.tidy_text:
+        suggest = pp_að.substituted_text(pp_að, "af")
+        if suggest == pp_að.tidy_text:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -282,7 +282,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AÐ",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_að.tidy_text,
                 suggest=suggest,
             )
         )
@@ -299,15 +299,15 @@ class PatternMatcher:
             pp = match.first_match('ADVP > { "af" }')
         if pp is None:
             return
+        pp_af = pp.first_match('"af"')
         # Calculate the start and end token indices, spanning both phrases
-        start, end = min(vp.span[0], pp.span[0]), max(vp.span[1], pp.span[1])
+        start, end = pp_af.span
         text = "Í '{0}' á 'af' sennilega að vera 'að'".format(vp.tidy_text)
-        # text = "'{0} af' á sennilega að vera '{0} að'".format(vp.tidy_text)
         detail = (
             "Í samhenginu 'að spyrja að e-u' er notuð " "forsetningin 'að', ekki 'af'."
         )
-        suggest = self.suggestion_complex(match, "spyrja", "af")
-        if suggest == match.tidy_text or not suggest:
+        suggest = pp_af.substituted_text(pp, "að")
+        if suggest == pp_af.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -317,7 +317,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AF",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_af.tidy_text,
                 suggest=suggest,
             )
         )
@@ -332,15 +332,16 @@ class PatternMatcher:
             pp = match.first_match('ADVP > { "af" }')
         if np is None or pp is None:
             return
+        pp_af = pp_af.first_match('"að"')
         # Calculate the start and end token indices, spanning both phrases
-        start, end = min(np.span[0], pp.span[0]), max(np.span[1], pp.span[1])
+        start, end = pp_af.span
         text = "'verða vitni af' á sennilega að vera 'verða vitni að'"
         detail = (
             "Í samhenginu 'verða vitni að e-u' er notuð "
             "forsetningin 'að', ekki 'af'."
         )
-        suggest = self.suggestion_complex(match, "vitni", "af")
-        if suggest == match.tidy_text or not suggest:
+        suggest = pp_af.substituted_text(pp_af, "að")
+        if suggest == pp_af.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -350,7 +351,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AF",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_af.tidy_text,
                 suggest=suggest,
             )
         )
@@ -366,20 +367,15 @@ class PatternMatcher:
             pp = match.first_match('ADVP > { "af" }')
         if np is None or pp is None:
             return
+        pp_af = pp.first_match('"af"')
         # Calculate the start and end token indices, spanning both phrases
-        if vp is None:
-            start, end = min(np.span[0], pp.span[0]), max(np.span[1], pp.span[1])
-        else:
-            start, end = (
-                min(vp.span[0], np.span[0], pp.span[0]),
-                max(vp.span[1], np.span[1], pp.span[1]),
-            )
+        start, end = pp_af.span
         text = "'gera grín af' á sennilega að vera 'gera grín að'"
         detail = (
             "Í samhenginu 'gera grín að e-u' er notuð " "forsetningin 'að', ekki 'af'."
         )
-        suggest = self.suggestion_complex(match, "grín", "af")
-        if suggest == match.tidy_text or not suggest:
+        suggest = pp_af.substituted_text(pp_af, "að")
+        if suggest == pp_af.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -389,7 +385,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AF",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_af.tidy_text,
                 suggest=suggest,
             )
         )
@@ -405,18 +401,16 @@ class PatternMatcher:
             pp = match.first_match('ADVP > { "af" }')
         if vp is None or np is None or pp is None:
             return
+        pp_af = pp.first_match('"af"')
         # Calculate the start and end token indices, spanning both phrases
-        start, end = (
-            min(vp.span[0], np.span[0], pp.span[0]),
-            max(vp.span[1], np.span[1], pp.span[1]),
-        )
+        start, end = pp_af.span
         text = "'leiða {0} af' á sennilega að vera 'leiða {0} að'".format(np.tidy_text)
         detail = (
             "Í samhenginu 'leiða {0} af e-u' er notuð "
             "forsetningin 'að', ekki 'af'.".format(np.tidy_text)
         )
-        suggest = self.suggestion_complex(match, "leiða", "af")
-        if suggest == match.tidy_text or not suggest:
+        suggest = pp_af.substituted_text(pp_af, "að")
+        if suggest == pp_af.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -426,7 +420,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AF",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_af.tidy_text,
                 suggest=suggest,
             )
         )
@@ -448,18 +442,16 @@ class PatternMatcher:
             pp = match.first_match('ADVP > { "af" }')
         if vp is None or np is None or pp is None:
             return
+        pp_af = pp.first_match('"af"')
         # Calculate the start and end token indices, spanning both phrases
-        start, end = (
-            min(vp.span[0], np.span[0], pp.span[0]),
-            max(vp.span[1], np.span[1], pp.span[1]),
-        )
+        start, end = pp_af.span
         text = "'marka upphaf af' á sennilega að vera 'marka upphaf að'"
         detail = (
             "Í samhenginu 'marka upphaf að e-u' er notuð "
             "forsetningin 'að', ekki 'af'."
         )
-        suggest = self.suggestion_complex(match, lemma, "af")
-        if suggest == match.tidy_text or not suggest:
+        suggest = pp_af.substituted_text(pp_af, "að")
+        if suggest == pp_af.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -469,7 +461,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AF",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_af.tidy_text,
                 suggest=suggest,
             )
         )
@@ -488,18 +480,16 @@ class PatternMatcher:
         np = match.first_match('NP >> { "velli" }')
         if vp is None or pp is None or np is None:
             return
+        pp_af = pp.first_match('"af"')
         # Calculate the start and end token indices, spanning both phrases
-        start, end = (
-            min(vp.span[0], pp.span[0], np.span[0]),
-            max(vp.span[-1], pp.span[-1], np.span[-1]),
-        )
+        start, end = pp_af.span
         text = "'leggja af velli' á sennilega að vera 'leggja að velli'"
         detail = (
             "Í samhenginu 'leggja einhvern að velli' er notuð "
             "forsetningin 'að', ekki 'af'."
         )
-        suggest = self.suggestion_complex(match, "leggja", "af")
-        if suggest == match.tidy_text or not suggest:
+        suggest = pp_af.substituted_text(pp_af, "að")
+        if suggest == pp_af.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -509,7 +499,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AF",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_af.tidy_text,
                 suggest=suggest,
             )
         )
@@ -524,15 +514,16 @@ class PatternMatcher:
         pp = match.first_match('ADVP > { "af" }')
         if advp is None or pp is None:
             return
+        pp_af = pp.first_match('"af"')
         # Calculate the start and end token indices, spanning both phrases
-        start, end = min(advp.span[0], pp.span[0]), max(advp.span[1], pp.span[1])
+        start, end = pp_af.span
         text = "'utan af' á sennilega að vera 'utan að'"
         detail = (
             "Í samhenginu 'kunna eitthvað utan að' er notuð "
             "forsetningin 'að', ekki 'af'."
         )
-        suggest = self.suggestion_complex(match, "utan", "af")
-        if suggest == match.tidy_text or not suggest:
+        suggest = pp_af.substituted_text(pp_af, "að")
+        if suggest == pp_af.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -542,7 +533,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AF",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_af.tidy_text,
                 suggest=suggest,
             )
         )
@@ -559,18 +550,16 @@ class PatternMatcher:
             pp = match.first_match("ADVP > { 'af' }")
         if vp is None or np is None or pp is None:
             return
+        pp_af = pp.first_match('"af"')
         # Calculate the start and end token indices, spanning both phrases
-        start, end = (
-            min(vp.span[0], np.span[0], pp.span[0]),
-            max(vp.span[1], np.span[1], pp.span[1]),
-        )
+        start, end = pp_af.span
         text = "'uppvís af' á sennilega að vera 'uppvís að'"
         detail = (
             "Í samhenginu 'verða uppvís að einhverju' er notuð "
             "forsetningin 'að', ekki 'af'."
         )
-        suggest = self.suggestion_complex(match, "uppvís", "af")
-        if suggest == match.tidy_text or not suggest:
+        suggest = pp_af.substituted_text(pp_af, "að")
+        if suggest == pp_af.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -580,7 +569,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AF",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_af.tidy_text,
                 suggest=suggest,
             )
         )
@@ -601,17 +590,15 @@ class PatternMatcher:
             np = match.first_match("NP >> 'ósk' ")
         if vp is None or pp is None or np is None:
             return
+        pp_af = pp.first_match('"af"')
         # Calculate the start and end token indices, spanning both phrases
-        start, end = (
-            min(vp.span[0], pp.span[0], np.span[0]),
-            max(pp.span[1], pp.span[1], np.span[1]),
-        )
+        start, end = pp_af.span
         text = "'af ósk' á sennilega að vera 'að ósk'"
         detail = (
             "Í samhenginu 'að verða að ósk' er notuð " "forsetningin 'að', ekki 'af'."
         )
-        suggest = self.suggestion_complex(match, "verða", "af")
-        if suggest == match.tidy_text or not suggest:
+        suggest = pp_af.substituted_text(pp_af, "að")
+        if suggest == pp_af.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -621,7 +608,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AF",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_af.tidy_text,
                 suggest=suggest,
             )
         )
@@ -655,14 +642,15 @@ class PatternMatcher:
         pp = match.first_match('PP > { "að" }')
         if np is None or pp is None:
             return
-        start, end = min(np.span[0], pp.span[0]), max(np.span[-1], pp.span[-1])
+        pp_að = pp.first_match('"að"')
+        start, end = pp_að.span
         text = "'{0} að' á sennilega að vera '{0} af'".format(np.tidy_text)
         detail = (
             "Í samhenginu 'hafa áhyggjur af e-u' er notuð "
             "forsetningin 'af', ekki 'að'."
         )
-        suggest = self.suggestion_complex(match, "áhyggja", "að")
-        if suggest == match.tidy_text or not suggest:
+        suggest = pp_að.substituted_text(pp_að, "af")
+        if suggest == pp_að.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -672,7 +660,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AÐ",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_að.tidy_text,
                 suggest=suggest,
             )
         )
@@ -684,11 +672,12 @@ class PatternMatcher:
         pp = match.first_match("PP > { 'að' }")
         if np is None or pp is None:
             return
-        start, end = min(np.span[0], pp.span[0]), max(np.span[-1], pp.span[-1])
+        pp_að = pp.first_match('"að"')
+        start, end = pp_að.span
         text = "'hluti að' á sennilega að vera 'hluti af'"
         detail = "Í samhenginu 'hluti af e-u' er notuð forsetningin 'af', ekki 'að'."
-        suggest = self.suggestion_complex(match, "hluti", "að")
-        if suggest == match.tidy_text or not suggest:
+        suggest = pp_að.substituted_text(pp_að, "af")
+        if suggest == pp_að.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -698,7 +687,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AÐ",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_að.tidy_text,
                 suggest=suggest,
             )
         )
@@ -709,15 +698,16 @@ class PatternMatcher:
         pp = match.first_match('PP > { "að" "mörkum" }')
         if pp is None:
             return
+        pp_að = pp.first_match('"að"')
         # Calculate the start and end token indices, spanning both phrases
-        start, end = pp.span
+        start, end = pp_að.span
         suggest = self.suggestion_complex(match, "leggja", "að")
-        text = f"'{pp.tidy_text}' á sennilega að vera '{suggest}'"
+        text = f"'{pp_að.tidy_text}' á sennilega að vera '{suggest}'"
         detail = (
             "Í samhenginu 'leggja e-ð af mörkum' er notuð "
             "forsetningin 'af', ekki 'að'."
         )
-        if suggest == pp.tidy_text or not suggest:
+        if suggest == pp_að.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -727,7 +717,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AÐ",
                 text=text,
                 detail=detail,
-                original=pp.tidy_text,
+                original=pp_að.tidy_text,
                 suggest=suggest,
             )
         )
@@ -735,17 +725,19 @@ class PatternMatcher:
     def wrong_preposition_að_leiða(self, match: SimpleTree) -> None:
         """Handle a match of a suspect preposition pattern"""
         # Calculate the start and end token indices, spanning both phrases
-        start, end = match.span
         pp = match.first_match("P > { 'að' }")
         if pp is None:
             return
-        suggest = self.suggestion_complex(match, "láta", "að")
-        text = f"'{match.tidy_text}' á sennilega að vera '{suggest}'"
+        pp_að = pp.first_match('"að"')
+        start, end = pp_að.span
+        suggest = pp_að.substituted_text(pp_að, "af")
+        whole = self.suggestion_complex(match, "láta", "að")
+        text = f"'{match.tidy_text}' á sennilega að vera '{whole}'"
         detail = (
             "Í samhenginu 'láta gott af sér leiða' er notuð "
             "forsetningin 'af', ekki 'að'."
         )
-        if suggest == match.tidy_text or not suggest:
+        if suggest == pp_að.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -755,7 +747,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AÐ",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_að.tidy_text,
                 suggest=suggest,
             )
         )
@@ -768,15 +760,17 @@ class PatternMatcher:
         pp = match.first_match("P > { 'að' }")
         if np is None or pp is None:
             return
+        pp_að = pp.first_match('"að"')
         # Calculate the start and end token indices, spanning both phrases
-        start, end = min(np.span[0], pp.span[0]), max(np.span[1], pp.span[1])
-        suggest = self.suggestion_complex(match, "heiður", "að")
-        text = f"'{match.tidy_text}' á sennilega að vera '{suggest}'"
+        start, end = pp_að.span
+        whole = self.suggestion_complex(match, "heiður", "að")
+        suggest = pp_að.substituted_text(pp_að, "af")
+        text = f"'{match.tidy_text}' á sennilega að vera '{whole}'"
         detail = (
             "Í samhenginu 'fá/hljóta heiðurinn af' er notuð "
             "forsetningin 'af', ekki 'að'."
         )
-        if suggest == match.tidy_text or not suggest:
+        if suggest == pp_að.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -786,7 +780,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AÐ",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_að.tidy_text,
                 suggest=suggest,
             )
         )
@@ -811,18 +805,17 @@ class PatternMatcher:
             pp = match.first_match('PP > { "að" }')
         if vp is None or pp is None:
             return
+        pp_að = pp.first_match('"að"')
         # Calculate the start and end token indices, spanning both phrases
-        start, end = (
-            min(vp.span[0], np.span[0], pp.span[0]),
-            max(vp.span[1], np.span[1], pp.span[1]),
-        )
-        suggest = self.suggestion_complex(match, "eiga", "að")
-        text = f"'{match.tidy_text}' á sennilega að vera '{suggest}'"
+        start, end = pp_að.span
+        suggest = pp_að.substituted_text(pp_að, "af")
+        whole = self.suggestion_complex(match, "eiga", "að")
+        text = f"'{match.tidy_text}' á sennilega að vera '{whole}'"
         detail = (
             f"Orðasambandið '{match.tidy_text}' tekur yfirleitt með sér "
             f"forsetninguna 'af', ekki 'að'."
         )
-        if suggest == match.tidy_text or not suggest:
+        if suggest == pp_að.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -832,31 +825,27 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AÐ",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_að.tidy_text,
                 suggest=suggest,
             )
         )
 
     def wrong_preposition_vera_til_að(self, match: SimpleTree) -> None:
         """Handle a match of a suspect preposition pattern"""
-        start, end = match.span
+        pp = match.first_match('P > { "að" }')
+        if pp is None:
+            pp = match.first_match('PP > { "að" }')
+        if pp is None:
+            return
+        pp_að = pp.first_match('"að"')
+        start, end = pp_að.span
         text = "'til að' á sennilega að vera 'til af'"
         detail = (
             "Orðasambandið 'vera mikið/lítið til af e-u' innifelur "
             "yfirleitt forsetninguna 'af', ekki 'að'."
         )
-        suggest = ""
-        if "mikill" in match.lemmas:
-            suggest = self.suggestion_complex(match, "mikill", "að")
-        elif "lítið" in match.lemmas:
-            suggest = self.suggestion_complex(match, "lítið", "að")
-        elif "lítill" in match.lemmas:
-            suggest = self.suggestion_complex(match, "lítill", "að")
-        elif "fullur" in match.lemmas:
-            suggest = self.suggestion_complex(match, "fullur", "að")
-        if suggest == "":
-            return
-        if suggest == match.tidy_text or not suggest:
+        suggest = pp_að.substituted_text(pp_að, "af")
+        if suggest == pp_að.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -866,21 +855,27 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AÐ",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_að.tidy_text,
                 suggest=suggest,
             )
         )
 
     def wrong_preposition_gagn_að(self, match: SimpleTree) -> None:
         """Handle a match of a suspect preposition pattern"""
-        start, end = match.span
+        pp = match.first_match('P > { "að" }')
+        if pp is None:
+            pp = match.first_match('PP > { "að" }')
+        if pp is None:
+            return
+        pp_að = pp.first_match('"að"')
+        start, end = pp_að.span
         text = "'gagn að' á sennilega að vera 'gagn af'"
         detail = (
             "Orðasambandið 'að hafa gagn af e-u' tekur yfirleitt með sér "
             "forsetninguna 'af', ekki 'að'."
         )
-        suggest = self.suggestion_complex(match, "gagn", "að")
-        if suggest == match.tidy_text or not suggest:
+        suggest = pp_að.substituted_text(pp_að, "af")
+        if suggest == pp_að.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -890,7 +885,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AÐ",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_að.tidy_text,
                 suggest=suggest,
             )
         )
@@ -898,18 +893,21 @@ class PatternMatcher:
     def wrong_preposition_frettir_að(self, match: SimpleTree) -> None:
         """Handle a match of a suspect preposition pattern"""
         # Find the offending preposition
-        pp = match.first_match("(P | ADVP) > { 'að' }")
+        pp = match.first_match('P > { "að" }')
+        if pp is None:
+            pp = match.first_match('PP > { "að" }')
         if pp is None:
             return
+        pp_að = pp.first_match('"að"')
+        start, end = pp_að.span
         # Calculate the start and end token indices, spanning both phrases
-        start, end = pp.span[0], pp.span[1]
         text = "'að' á sennilega að vera 'af'"
         detail = (
             "Orðasambandið 'fréttir berast af e-u' tekur yfirleitt með sér "
             "forsetninguna 'af', ekki 'að'."
         )
-        suggest = self.suggestion_complex(match, "frétt", "að")
-        if suggest == match.tidy_text or not suggest:
+        suggest = pp_að.substituted_text(pp_að, "af")
+        if suggest == pp_að.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -919,7 +917,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AÐ",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_að.tidy_text,
                 suggest=suggest,
             )
         )
@@ -930,17 +928,24 @@ class PatternMatcher:
         vp = match.first_match("VP > { 'stafa' }")
         if vp is None:
             return
-        start, end = match.span
-        suggest = self.suggestion_complex(match, "stafa", "að")
+        pp = vp.first_match('P > { "að" }')
+        if pp is None:
+            pp = vp.first_match('PP > { "að" }')
+        if pp is None:
+            return
+        pp_að = pp.first_match('"að"')
+        start, end = pp_að.span
+        suggest = pp_að.substituted_text(pp_að, "af")
+        whole = self.suggestion_complex(match, "stafa", "að")
         if " að " in vp.tidy_text:
-            text = "'{0}' á sennilega að vera '{1}'".format(match.tidy_text, suggest)
+            text = "'{0}' á sennilega að vera '{1}'".format(match.tidy_text, whole)
         else:
             text = "'{0} að' á sennilega að vera '{0} af'".format(vp.tidy_text)
         detail = (
             "Orðasambandið 'að stafa af e-u' tekur yfirleitt með sér "
             "forsetninguna 'af', ekki 'að'."
         )
-        if suggest == match.tidy_text:
+        if suggest == pp_að.tidy_text:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -950,38 +955,39 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AÐ",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_að.tidy_text,
                 suggest=suggest,
             )
         )
 
-    def wrong_preposition_ólétt_að(self, match: SimpleTree) -> None:
+    def wrong_preposition_ólétt_af(self, match: SimpleTree) -> None:
         """Handle a match of a suspect preposition pattern"""
         # Find the offending nominal phrase
         np = match.first_match("NP > { 'óléttur' }")
         # Find the attached prepositional phrase
-        pp = match.first_match("P > { 'að' }")
+        pp = match.first_match("P > { 'af' }")
         if np is None or pp is None:
             return
+        pp_af = pp.first_match('"af"')
         # Calculate the start and end token indices, spanning both phrases
-        start, end = min(np.span[0], pp.span[0]), max(np.span[1], pp.span[1])
-        text = "'{0} að' á sennilega að vera '{0} af'".format(np.tidy_text)
+        start, end = pp_af.span
+        text = "'{0} af' á sennilega að vera '{0} að'".format(np.tidy_text)
         detail = (
-            "Orðasambandið 'að vera ólétt/ur af e-u' tekur yfirleitt með sér "
-            "forsetninguna 'af', ekki 'að'."
+            "Orðasambandið 'að vera ólétt/ur að e-u' tekur yfirleitt með sér "
+            "forsetninguna 'að', ekki 'af'."
         )
-        suggest = self.suggestion_complex(match, "óléttur", "að")
-        if suggest == match.tidy_text or not suggest:
+        suggest = pp_af.substituted_text(pp_af, "að")
+        if suggest == pp_af.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
             Annotation(
                 start=start,
                 end=end,
-                code="P_WRONG_PREP_AÐ",
+                code="P_WRONG_PREP_AF",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_af.tidy_text,
                 suggest=suggest,
             )
         )
@@ -994,15 +1000,17 @@ class PatternMatcher:
         pp = match.first_match("P > { 'að' }")
         if vp is None or pp is None:
             return
+        pp_að = pp.first_match('"að"')
         # Calculate the start and end token indices, spanning both phrases
-        start, end = min(vp.span[0], pp.span[0]), max(vp.span[1], pp.span[1])
-        suggest = self.suggestion_complex(match, "heyra", "að")
-        text = "'{0}' á sennilega að vera '{1}'".format(match.tidy_text, suggest)
+        start, end = pp_að.span
+        suggest = pp_að.substituted_text(pp_að, "af")
+        whole = self.suggestion_complex(match, "heyra", "að")
+        text = "'{0}' á sennilega að vera '{1}'".format(match.tidy_text, whole)
         detail = (
             "Orðasambandið 'að heyra af e-u' tekur yfirleitt með sér "
             "forsetninguna 'af', ekki 'að'."
         )
-        if suggest == match.tidy_text or not suggest:
+        if suggest == pp_að.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -1012,7 +1020,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AÐ",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_að.tidy_text,
                 suggest=suggest,
             )
         )
@@ -1025,15 +1033,16 @@ class PatternMatcher:
         pp = match.first_match("P > { 'að' }")
         if np is None or pp is None:
             return
+        pp_að = pp.first_match('"að"')
         # Calculate the start and end token indices, spanning both phrases
-        start, end = min(np.span[0], pp.span[0]), max(np.span[1], pp.span[1])
+        start, end = pp_að.span
         text = "'gaman að' á sennilega að vera 'gaman af'"
         detail = (
             "Orðasambandið 'að hafa gaman af e-u' tekur yfirleitt með sér "
             "forsetninguna 'af', ekki 'að'."
         )
-        suggest = self.suggestion_complex(match, "gaman", "að")
-        if suggest == match.tidy_text or not suggest:
+        suggest = pp_að.substituted_text(pp_að, "af")
+        if suggest == pp_að.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -1043,7 +1052,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AÐ",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_að.tidy_text,
                 suggest=suggest,
             )
         )
@@ -1051,13 +1060,17 @@ class PatternMatcher:
     def wrong_preposition_heillaður_að(self, match: SimpleTree) -> None:
         """Handle a match of a suspect preposition pattern"""
         # Calculate the start and end token indices, spanning both phrases
-        start, end = match.span
+        pp = match.first_match("P > { 'að' }")
+        if pp is None:
+            return
+        pp_að = pp.first_match('"að"')
+        start, end = pp_að.span
         text = "'heillaður að' á sennilega að vera 'heillaður af'"
         detail = (
             "Í samhenginu 'heillaður af e-u' er notuð " "forsetningin 'af', ekki 'að'."
         )
-        suggest = self.suggestion_complex(match, "heillaður", "að")
-        if suggest == match.tidy_text or not suggest:
+        suggesst = pp_að.substituted_text(pp_að, "af")
+        if suggest == pp_að.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -1067,7 +1080,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AÐ",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_að.tidy_text,
                 suggest=suggest,
             )
         )
@@ -1080,9 +1093,11 @@ class PatternMatcher:
         if vp is None:
             vp = match.first_match("NP > { 'valinn' }")
             lemma = "valinn"
-        if vp is None:
+        pp = match.first_match('P > { "að" }')
+        if vp is None or pp is None:
             return
-        start, end = match.span
+        pp_að = pp.first_match('"að"')
+        pp = pp_að.span
         if " að " in vp.tidy_text:
             text = "'{0}' á sennilega að vera '{1}'".format(
                 vp.tidy_text, vp.tidy_text.replace(" að ", " af ")
@@ -1093,8 +1108,8 @@ class PatternMatcher:
             "Orðasambandið 'að vera valin/n af e-m' tekur yfirleitt með sér "
             "forsetninguna 'af', ekki 'að'."
         )
-        suggest = self.suggestion_complex(match, lemma, "að")
-        if suggest == match.tidy_text or not suggest:
+        suggest = pp_að.substituted_text(pp_að, "af")
+        if suggest == pp_að.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -1104,7 +1119,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AÐ",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_að.tidy_text,
                 suggest=suggest,
             )
         )
@@ -1121,7 +1136,7 @@ class PatternMatcher:
         if pp_að is None:
             return
         # Calculate the start and end token indices, spanning both phrases
-        start, end = min(np.span[0], pp.span[0]), max(np.span[1], pp.span[1])
+        start, end = pp_að
         suggest = match.substituted_text(pp_að, "af")
         text = "Hér á líklega að vera forsetningin 'af' í stað 'að'."
         detail = (
@@ -1138,7 +1153,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AÐ",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_að.tidy_text,
                 suggest=suggest,
             )
         )
@@ -1254,15 +1269,15 @@ class PatternMatcher:
         if pp_af is None:
             return
         # Calculate the start and end token indices, spanning both phrases
-        start, end = min(np.span[0], pp.span[0]), max(np.span[1], pp.span[1])
+        start, end = pp_af.span
         text = "Hér á líklega að vera forsetningin 'að' í stað 'af'."
         detail = (
             "Í samhenginu '{0}' er rétt að nota forsetninguna 'að' í stað 'af'.".format(
                 match.tidy_text
             )
         )
-        suggest = match.substituted_text(pp_af, "að")
-        if suggest == match.tidy_text:
+        suggest = pp_af.substituted_text(pp_af, "að")
+        if suggest == pp_af.tidy_text:
             # No need to annotate, no changes were made
             return
         self._ann.append(
@@ -1272,7 +1287,7 @@ class PatternMatcher:
                 code="P_WRONG_PREP_AF",
                 text=text,
                 detail=detail,
-                original=match.tidy_text,
+                original=pp_af.tidy_text,
                 suggest=suggest,
             )
         )
@@ -1310,6 +1325,9 @@ class PatternMatcher:
         if realso is None:
             return
         _, end = realso.span
+        if "þt" in so.all_variants:
+            # The past tense behaves differently, much less likely to be an error
+            return
         suggest = self.get_wordform(
             realso.text.lower(), realso.lemma, realso.cat, so.all_variants
         )
@@ -2279,12 +2297,12 @@ class PatternMatcher:
                     None,
                 )
             )
-            # Catch "Hún er (ekki) ólétt að sínu þriðja barni.", "Hún hefur (ekki) verið ólétt að sínu þriðja barni."
+            # Catch "Hún er (ekki) ólétt af sínu þriðja barni.", "Hún hefur (ekki) verið ólétt af sínu þriðja barni."
             cls.add_pattern(
                 (
                     "óléttur",  # Trigger lemma for this pattern
-                    "VP > { NP > { 'óléttur' } PP > { 'að' } }",
-                    cls.wrong_preposition_ólétt_að,
+                    "VP > { NP > { 'óléttur' } PP > { 'af' } }",
+                    cls.wrong_preposition_ólétt_af,
                     None,
                 )
             )

--- a/src/reynir_correct/pattern.py
+++ b/src/reynir_correct/pattern.py
@@ -300,6 +300,8 @@ class PatternMatcher:
         if pp is None:
             return
         pp_af = pp.first_match('"af"')
+        if pp_af is None:
+            return
         # Calculate the start and end token indices, spanning both phrases
         start, end = pp_af.span
         text = "Í '{0}' á 'af' sennilega að vera 'að'".format(vp.tidy_text)
@@ -332,7 +334,9 @@ class PatternMatcher:
             pp = match.first_match('ADVP > { "af" }')
         if np is None or pp is None:
             return
-        pp_af = pp_af.first_match('"að"')
+        pp_af = pp.first_match('"að"')
+        if pp_af is None:
+            return
         # Calculate the start and end token indices, spanning both phrases
         start, end = pp_af.span
         text = "'verða vitni af' á sennilega að vera 'verða vitni að'"
@@ -368,6 +372,8 @@ class PatternMatcher:
         if np is None or pp is None:
             return
         pp_af = pp.first_match('"af"')
+        if pp_af is None:
+            return
         # Calculate the start and end token indices, spanning both phrases
         start, end = pp_af.span
         text = "'gera grín af' á sennilega að vera 'gera grín að'"
@@ -402,6 +408,8 @@ class PatternMatcher:
         if vp is None or np is None or pp is None:
             return
         pp_af = pp.first_match('"af"')
+        if pp_af is None:
+            return
         # Calculate the start and end token indices, spanning both phrases
         start, end = pp_af.span
         text = "'leiða {0} af' á sennilega að vera 'leiða {0} að'".format(np.tidy_text)
@@ -443,6 +451,8 @@ class PatternMatcher:
         if vp is None or np is None or pp is None:
             return
         pp_af = pp.first_match('"af"')
+        if pp_af is None:
+            return
         # Calculate the start and end token indices, spanning both phrases
         start, end = pp_af.span
         text = "'marka upphaf af' á sennilega að vera 'marka upphaf að'"
@@ -481,6 +491,8 @@ class PatternMatcher:
         if vp is None or pp is None or np is None:
             return
         pp_af = pp.first_match('"af"')
+        if pp_af is None:
+            return
         # Calculate the start and end token indices, spanning both phrases
         start, end = pp_af.span
         text = "'leggja af velli' á sennilega að vera 'leggja að velli'"
@@ -515,6 +527,8 @@ class PatternMatcher:
         if advp is None or pp is None:
             return
         pp_af = pp.first_match('"af"')
+        if pp_af is None:
+            return
         # Calculate the start and end token indices, spanning both phrases
         start, end = pp_af.span
         text = "'utan af' á sennilega að vera 'utan að'"
@@ -551,6 +565,8 @@ class PatternMatcher:
         if vp is None or np is None or pp is None:
             return
         pp_af = pp.first_match('"af"')
+        if pp_af is None:
+            return
         # Calculate the start and end token indices, spanning both phrases
         start, end = pp_af.span
         text = "'uppvís af' á sennilega að vera 'uppvís að'"
@@ -591,6 +607,8 @@ class PatternMatcher:
         if vp is None or pp is None or np is None:
             return
         pp_af = pp.first_match('"af"')
+        if pp_af is None:
+            return
         # Calculate the start and end token indices, spanning both phrases
         start, end = pp_af.span
         text = "'af ósk' á sennilega að vera 'að ósk'"
@@ -643,6 +661,8 @@ class PatternMatcher:
         if np is None or pp is None:
             return
         pp_að = pp.first_match('"að"')
+        if pp_að is None:
+            return
         start, end = pp_að.span
         text = "'{0} að' á sennilega að vera '{0} af'".format(np.tidy_text)
         detail = (
@@ -673,6 +693,8 @@ class PatternMatcher:
         if np is None or pp is None:
             return
         pp_að = pp.first_match('"að"')
+        if pp_að is None:
+            return
         start, end = pp_að.span
         text = "'hluti að' á sennilega að vera 'hluti af'"
         detail = "Í samhenginu 'hluti af e-u' er notuð forsetningin 'af', ekki 'að'."
@@ -699,6 +721,8 @@ class PatternMatcher:
         if pp is None:
             return
         pp_að = pp.first_match('"að"')
+        if pp_að is None:
+            return
         # Calculate the start and end token indices, spanning both phrases
         start, end = pp_að.span
         suggest = self.suggestion_complex(match, "leggja", "að")
@@ -729,6 +753,8 @@ class PatternMatcher:
         if pp is None:
             return
         pp_að = pp.first_match('"að"')
+        if pp_að is None:
+            return
         start, end = pp_að.span
         suggest = pp_að.substituted_text(pp_að, "af")
         whole = self.suggestion_complex(match, "láta", "að")
@@ -761,6 +787,8 @@ class PatternMatcher:
         if np is None or pp is None:
             return
         pp_að = pp.first_match('"að"')
+        if pp_að is None:
+            return
         # Calculate the start and end token indices, spanning both phrases
         start, end = pp_að.span
         whole = self.suggestion_complex(match, "heiður", "að")
@@ -806,6 +834,8 @@ class PatternMatcher:
         if vp is None or pp is None:
             return
         pp_að = pp.first_match('"að"')
+        if pp_að is None:
+            return
         # Calculate the start and end token indices, spanning both phrases
         start, end = pp_að.span
         suggest = pp_að.substituted_text(pp_að, "af")
@@ -838,6 +868,8 @@ class PatternMatcher:
         if pp is None:
             return
         pp_að = pp.first_match('"að"')
+        if pp_að is None:
+            return
         start, end = pp_að.span
         text = "'til að' á sennilega að vera 'til af'"
         detail = (
@@ -868,6 +900,8 @@ class PatternMatcher:
         if pp is None:
             return
         pp_að = pp.first_match('"að"')
+        if pp_að is None:
+            return
         start, end = pp_að.span
         text = "'gagn að' á sennilega að vera 'gagn af'"
         detail = (
@@ -899,6 +933,8 @@ class PatternMatcher:
         if pp is None:
             return
         pp_að = pp.first_match('"að"')
+        if pp_að is None:
+            return
         start, end = pp_að.span
         # Calculate the start and end token indices, spanning both phrases
         text = "'að' á sennilega að vera 'af'"
@@ -934,6 +970,8 @@ class PatternMatcher:
         if pp is None:
             return
         pp_að = pp.first_match('"að"')
+        if pp_að is None:
+            return
         start, end = pp_að.span
         suggest = pp_að.substituted_text(pp_að, "af")
         whole = self.suggestion_complex(match, "stafa", "að")
@@ -969,6 +1007,8 @@ class PatternMatcher:
         if np is None or pp is None:
             return
         pp_af = pp.first_match('"af"')
+        if pp_af is None:
+            return
         # Calculate the start and end token indices, spanning both phrases
         start, end = pp_af.span
         text = "'{0} af' á sennilega að vera '{0} að'".format(np.tidy_text)
@@ -1001,6 +1041,8 @@ class PatternMatcher:
         if vp is None or pp is None:
             return
         pp_að = pp.first_match('"að"')
+        if pp_að is None:
+            return
         # Calculate the start and end token indices, spanning both phrases
         start, end = pp_að.span
         suggest = pp_að.substituted_text(pp_að, "af")
@@ -1034,6 +1076,8 @@ class PatternMatcher:
         if np is None or pp is None:
             return
         pp_að = pp.first_match('"að"')
+        if pp_að is None:
+            return
         # Calculate the start and end token indices, spanning both phrases
         start, end = pp_að.span
         text = "'gaman að' á sennilega að vera 'gaman af'"
@@ -1064,12 +1108,14 @@ class PatternMatcher:
         if pp is None:
             return
         pp_að = pp.first_match('"að"')
+        if pp_að is None:
+            return
         start, end = pp_að.span
         text = "'heillaður að' á sennilega að vera 'heillaður af'"
         detail = (
             "Í samhenginu 'heillaður af e-u' er notuð " "forsetningin 'af', ekki 'að'."
         )
-        suggesst = pp_að.substituted_text(pp_að, "af")
+        suggest = pp_að.substituted_text(pp_að, "af")
         if suggest == pp_að.tidy_text or not suggest:
             # No need to annotate, no changes were made
             return
@@ -1097,7 +1143,9 @@ class PatternMatcher:
         if vp is None or pp is None:
             return
         pp_að = pp.first_match('"að"')
-        pp = pp_að.span
+        if pp_að is None:
+            return
+        start, end = pp_að.span
         if " að " in vp.tidy_text:
             text = "'{0}' á sennilega að vera '{1}'".format(
                 vp.tidy_text, vp.tidy_text.replace(" að ", " af ")
@@ -1136,7 +1184,7 @@ class PatternMatcher:
         if pp_að is None:
             return
         # Calculate the start and end token indices, spanning both phrases
-        start, end = pp_að
+        start, end = pp_að.span
         suggest = match.substituted_text(pp_að, "af")
         text = "Hér á líklega að vera forsetningin 'af' í stað 'að'."
         detail = (

--- a/test/test_allkinds.py
+++ b/test/test_allkinds.py
@@ -542,7 +542,7 @@ def test_capitalization(verbose=False):
     assert "Íslandi" in s
     assert "Íslendingar" in s
     assert "Danmörku" in s
-    assert "danskir" in s
+    # assert "danskir" in s            # Most likely an adjective at the start of a named entity (Danska ríkisútvarpið, Íslensk erfðagreining)
     assert "Danir" in s
     assert "nóvember" in s
     assert "Nóvember" not in s
@@ -550,7 +550,7 @@ def test_capitalization(verbose=False):
     assert g[2].error_code == "Z002"  # Íslandi
     assert g[4].error_code == "Z002"  # Íslendingar
     assert g[7].error_code == "Z002"  # Danmörku
-    assert g[9].error_code == "Z001"  # danskir
+    # assert g[9].error_code == "Z001"  # danskir
     assert g[10].error_code == "Z002"  # Danir
     assert g[12].error_code == "Z003"  # nóvember
     assert g[15].error_code == "Z002"  # Fríslendingar
@@ -1229,12 +1229,12 @@ def test_verb_agreement(verbose=False):
     # komið inn í Verbs.conf. Þetta er líklega ekki réttur villukóði.
     # check_sentence(s, [(2, 2, "P_WRONG_PARTICLE_uppi")])
     s = "Maðurinn dáðist af málverkinu."
-    check_sentence(s, [(1, 2, "P_WRONG_PREP_AF")])
+    check_sentence(s, [(2, 2, "P_WRONG_PREP_AF")])
     s = "Barnið á hættu á að detta í brunninn."
     # TODO erfitt að eiga við, líklega ekki réttur villukóði, bæta við Verbs.conf.
     # check_sentence(s, [(1, 1, "P_WRONG_FORM")])
     s = "Hetjan á heiður að björguninni."
-    check_sentence(s, [(1, 4, "P_WRONG_PREP_AÐ")])
+    check_sentence(s, [(3, 3, "P_WRONG_PREP_AÐ")])
     s = "Ferðafólkið fór erlendis að leita lamba."
     # TODO villan greinist ekki. Komið í Verbs.conf? Líklega ekki réttur villukóði.
     # check_sentence(s, [(2, 3, "P_WRONG_PARTICLE_til_útlanda")])
@@ -1278,8 +1278,8 @@ def test_vera(verbose=False):
     # vera að + so.nh.
     s = "Ég er ekki að skilja þetta."
     check_sentence(s, [(1, 4, "P_VeraAð")])
-    s = "Ég var að fara í sund þegar ég fékk símtalið."
-    check_sentence(s, [(1, 3, "P_VeraAð")])
+    s = "Ég er að fara í sund þegar ég fæ símtalið."
+    # check_sentence(s, [(1, 3, "P_VeraAð")])
     s = "Hún er að skrifa vel."
     # check_sentence(s, [(1, 3, "P_VeraAð")]) # Greinist ekki lengur sem villa, undanskil 3.p. pfn. því geta verið ómannleg.
     s = "Kristín er að skrifa vel."

--- a/test/test_patterns.py
+++ b/test/test_patterns.py
@@ -52,154 +52,161 @@ def rc():
 
 def test_verb_af(rc):
     s = "Ráðherrann dáðist af hugrekki stjórnarandstöðunnar."
-    check_sentence(rc, s, [(1, 2, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(2, 2, "P_WRONG_PREP_AF")])
 
     s = (
         "Mig langaði að leita af bílnum, en dáðist svo af hugrekki lögreglukonunnar "
         "að ég gerði það ekki."
     )
-    check_sentence(rc, s, [(3, 4, "P_WRONG_PREP_AF"), (8, 10, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AF"), (10, 10, "P_WRONG_PREP_AF")])
 
     s = "Við höfum leitað í allan dag af kettinum, en fundum hann ekki."
-    check_sentence(rc, s, [(2, 4, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AF")])
 
     s = "Allan daginn höfum við leitað af kettinum."
-    check_sentence(rc, s, [(4, 5, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(5, 5, "P_WRONG_PREP_AF")])
 
     s = "Páll brosti af töktunum í Gunnu."
-    check_sentence(rc, s, [(1, 2, "P_WRONG_PREP_AF")], ignore_warnings=True)
+    check_sentence(rc, s, [(2, 2, "P_WRONG_PREP_AF")], ignore_warnings=True)
 
     s = "Ég var leitandi af kettinum í allan dag."
-    check_sentence(rc, s, [(2, 3, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AF")])
 
     s = "Ég vildi leita af mér allan grun."
     check_sentence(rc, s, [])
 
     s = "Hver leitar af skrifstofuhúsnæði?"
-    check_sentence(rc, s, [(1, 2, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(2, 2, "P_WRONG_PREP_AF")])
 
     s = "Hann dáist endalaust af þeim."
-    check_sentence(rc, s, [(1, 3, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AF")])
 
     s = "Hann hefur lengi dáðst af þeim."
-    check_sentence(rc, s, [(3, 4, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AF")])
 
     s = "Jón gerir grín af því."
-    check_sentence(rc, s, [(1, 4, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AF")])
 
     s = "Þetta er mesta vitleysa sem ég hef gert grín af."
-    check_sentence(rc, s, [(6, 9, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(9, 9, "P_WRONG_PREP_AF")])
 
     s = "Jón kann það ekki utan af."
-    check_sentence(rc, s, [(4, 5, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(5, 5, "P_WRONG_PREP_AF")])
 
     s = "Jón leggur hann ekki af velli."
-    check_sentence(rc, s, [(1, 5, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AF")])
 
     s = "Jón hefur ekki lagt hann af velli."
     # TODO "af velli" ends up under "hann"
     # check_sentence(rc, s, [(1, 6, "P_WRONG_PREP_AF")])
 
     s = "Jón leiðir líkur af því."
-    check_sentence(rc, s, [(1, 4, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AF")])
 
     s = "Jón leiðir ekki líkur af því."
-    check_sentence(rc, s, [(1, 5, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AF")])
 
     s = "Jón leiðir rök af því."
-    check_sentence(rc, s, [(1, 4, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AF")])
 
     s = "Jón leitar af því."
-    check_sentence(rc, s, [(1, 2, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(2, 2, "P_WRONG_PREP_AF")])
 
     s = "Tíminn markar upphaf af því."
-    check_sentence(rc, s, [(1, 4, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AF")])
 
     s = "Tíminn markar ekki upphaf af því."
-    check_sentence(rc, s, [(1, 5, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AF")])
 
     s = "Það markar upphafið af því."
-    check_sentence(rc, s, [(1, 4, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AF")])
 
     s = "Það markar ekki upphafið af því."
-    check_sentence(rc, s, [(1, 5, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AF")])
 
     s = "Það hefur ekki markað upphafið af því."
-    check_sentence(rc, s, [(1, 6, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(5, 5, "P_WRONG_PREP_AF")])
 
     s = "Jón spyr af því."
     # TODO not picked up
     # check_sentence(rc, s, [(1, 2, "P_WRONG_PREP_AF")])
 
     s = "Það sem Jón spurði ekki af var óljóst."
-    check_sentence(rc, s, [(2, 5, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(5, 5, "P_WRONG_PREP_AF")])
 
     s = "Jón stuðlar af því."
     # TODO not picked up
-    # check_sentence(rc, s, [(1, 2, "P_WRONG_PREP_AF")])
+    # check_sentence(rc, s, [(2, 2, "P_WRONG_PREP_AF")])
 
     s = "Honum varð af ósk sinni."
-    check_sentence(rc, s, [(1, 4, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(2, 2, "P_WRONG_PREP_AF")])
 
     s = "Honum hafði orðið af ósk sinni."
-    check_sentence(rc, s, [(2, 5, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AF")])
 
     s = "Honum varð ekki af ósk sinni."
-    check_sentence(rc, s, [(1, 5, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AF")])
 
     s = "Hann varð ekki uppvís af því."
-    check_sentence(rc, s, [(1, 5, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AF")])
 
     s = "Jón varð vitni af þessu."
     check_sentence(rc, s, [(1, 3, "P_afað"), (3, 3, "S005")])
 
+    s = "Hún er ólétt af sínu þriðja barni."
+    check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AF")])
+    #    s = "Það kom henni á óvart að hún væri ólétt af strák." # Annotation variable depending on parse
+    #    check_sentence(rc, s, [(8, 9, "P_WRONG_PREP_AF")])
+    s = "Að öllu leyti eru öll ólétt af stelpum."
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AF")])
+
 
 def test_noun_af(rc):
     s = "Hann gerði þetta af beiðni hennar."
-    check_sentence(rc, s, [(3, 4, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AF")])
     s = "Af beiðni hennar gerði hann þetta."
-    check_sentence(rc, s, [(0, 1, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(0, 0, "P_WRONG_PREP_AF")])
     s = "Það var gert af þeirri fyrirmynd."
-    check_sentence(rc, s, [(3, 5, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AF")])
     s = "Þau gera þetta af heiðnum sið."
-    check_sentence(rc, s, [(3, 5, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AF")])
     s = "Ég baka köku af því tilefni."
-    check_sentence(rc, s, [(3, 5, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AF")])
     s = "Þau veittu mér aðgang af kerfinu."
-    check_sentence(rc, s, [(3, 4, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AF")])
     s = "Aðgangur af kerfinu var veittur."
-    check_sentence(rc, s, [(0, 1, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(1, 1, "P_WRONG_PREP_AF")])
     s = "Drög af verkefninu eru tilbúin."
-    check_sentence(rc, s, [(0, 1, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(1, 1, "P_WRONG_PREP_AF")])
     #    s = "Þau kláruðu drög af verkefninu."
     #    check_sentence(rc, s, [(2, 3, "P_WRONG_PREP_AF")])
     s = "Grunnur af verkefninu er tilbúinn."
-    check_sentence(rc, s, [(0, 1, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(1, 1, "P_WRONG_PREP_AF")])
     #    s = "Hann lagði ekki grunninn af verkefninu."
     #    check_sentence(rc, s, [(3, 4, "P_WRONG_PREP_AF")])
     #    s = "Þau gerðu leit af dótinu."
     #    check_sentence(rc, s, [(2, 3, "P_WRONG_PREP_AF")])
     s = "Leit af dótinu hefur ekki skilað árangri."
-    check_sentence(rc, s, [(0, 1, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(1, 1, "P_WRONG_PREP_AF")])
     s = "Þetta er lykillinn af velgengni."
-    check_sentence(rc, s, [(2, 3, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AF")])
     s = "Hann gaf mér uppskriftina af réttinum."
-    check_sentence(rc, s, [(3, 4, "P_WRONG_PREP_AF")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AF")])
 
 
 def test_verb_að(rc):
     s = "Ég er ekki hluti að heildinni."
-    check_sentence(rc, s, [(2, 5, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AÐ")])
     s = "Við höfum öll verið hluti að heildinni."
-    check_sentence(rc, s, [(4, 6, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(5, 5, "P_WRONG_PREP_AÐ")])
     s = "Vissulega er hægt að vera hluti að heildinni."
-    check_sentence(rc, s, [(5, 7, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(6, 6, "P_WRONG_PREP_AÐ")])
     #    s = "Þeir sögðu að ég hefði verið hluti að heildinni."   # Annotation variable depending on parsing
     #    check_sentence(rc, s, [(6, 8, "P_WRONG_PREP_AÐ")])
     s = "Að öllu óbreyttu er hann hluti að heildinni."
-    check_sentence(rc, s, [(5, 7, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(6, 6, "P_WRONG_PREP_AÐ")])
     s = "Ég vildi vera hluti að heildinni að mestu leyti."
-    check_sentence(rc, s, [(3, 5, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AÐ")])
     s = "Þar að leiðandi virkar þetta."
     check_sentence(rc, s, [(0, 2, "P_aðaf"), (1, 1, "S005")])
     s = "Þar að leiðandi virkar þetta að mestu leyti."
@@ -211,39 +218,39 @@ def test_verb_að(rc):
     s = "Ég hef áhyggjur að því að honum líði illa."
     # check_sentence(rc, s, [(2, 8, "P_WRONG_PREP_AÐ")])
     s = "Ég lagði ekki mikið að mörkum."
-    check_sentence(rc, s, [(4, 5, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AÐ")])
     s = "Ég hafði lagt mikið að mörkum."
-    check_sentence(rc, s, [(4, 5, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AÐ")])
     s = "Sama hvað ég gerði lagði ég mikið að mörkum."
-    check_sentence(rc, s, [(7, 8, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(7, 7, "P_WRONG_PREP_AÐ")])
     s = "Að hans mati lagði hann mikið að mörkum."
-    check_sentence(rc, s, [(6, 7, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(6, 6, "P_WRONG_PREP_AÐ")])
     s = "Ég heillast að þannig fólki."
-    check_sentence(rc, s, [(1, 2, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(2, 2, "P_WRONG_PREP_AÐ")])
     s = "Það að heillast að þannig fólki er algengt."
-    check_sentence(rc, s, [(2, 3, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AÐ")])
     s = "Ég lét gott að mér leiða."
-    check_sentence(rc, s, [(1, 5, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AÐ")])
     s = "Að mínu mati lét ég ekki gott að mér leiða."
-    check_sentence(rc, s, [(3, 9, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(7, 7, "P_WRONG_PREP_AÐ")])
     s = "Hún á heiðurinn að þessu."
-    check_sentence(rc, s, [(1, 4, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AÐ")])
     s = "Hún hafði ekki átt heiðurinn að þessu en fékk heiðurinn að þessu."
-    check_sentence(rc, s, [(1, 6, "P_WRONG_PREP_AÐ"), (9, 11, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(5, 5, "P_WRONG_PREP_AÐ"), (10, 10, "P_WRONG_PREP_AÐ")])
     s = "Hún hlaut heiðurinn að þessu."
-    check_sentence(rc, s, [(2, 4, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AÐ")])
     s = "Að endingu hljótum við öll heiðurinn að því."
-    check_sentence(rc, s, [(4, 6, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(5, 5, "P_WRONG_PREP_AÐ")])
     s = "Hún á heilan helling að börnum."
-    check_sentence(rc, s, [(1, 5, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AÐ")])
     s = "Hún á marga að."
     check_sentence(rc, s, [])
     s = "Að mínu mati eigum við mikið að mat."
-    check_sentence(rc, s, [(3, 7, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(6, 6, "P_WRONG_PREP_AÐ")])
     s = "Hún á ekki aðild að málinu."
     check_sentence(rc, s, [])
     s = "Hún hefur ekki haft gagn að þessu."
-    check_sentence(rc, s, [(1, 6, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(5, 5, "P_WRONG_PREP_AÐ")])
     s = "Að mínu mati hef ég ekki gagn að þessu."
     # check_sentence(rc, s, [(3, 8, "P_WRONG_PREP_AÐ")])
     s = "Þetta hafði ekki komið að sjálfu sér."
@@ -253,47 +260,41 @@ def test_verb_að(rc):
     s = "Að endingu berast fréttir að slysinu."
     check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AÐ")])
     s = "Þetta er afgreitt mál að minni hálfu."
-    check_sentence(rc, s, [(4, 6, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AÐ")])
     s = "Hætta hefur aldrei stafað að þessu."
-    check_sentence(rc, s, [(1, 5, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AÐ")])
     #    s = "Að mínu mati stafar ekki hætta að þessu."  # Annotation variable depending on parse
     #    check_sentence(rc, s, [(3, 7, "P_WRONG_PREP_AÐ")])
-    s = "Hún er ólétt að sínu þriðja barni."
-    check_sentence(rc, s, [(2, 3, "P_WRONG_PREP_AÐ")])
-    #    s = "Það kom henni á óvart að hún væri ólétt að strák." # Annotation variable depending on parse
-    #    check_sentence(rc, s, [(8, 9, "P_WRONG_PREP_AÐ")])
-    s = "Að öllu leyti eru öll ólétt að stelpum."
-    check_sentence(rc, s, [(2, 4, "P_WRONG_PREP_AÐ")])
     s = "Hann hefur ekki heyrt að lausa starfinu."
-    check_sentence(rc, s, [(1, 6, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AÐ")])
     s = "Að endingu heyrði ég að starfinu."
-    check_sentence(rc, s, [(1, 4, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(3, 3, "P_WRONG_PREP_AÐ")])
     s = "Ég hef aldrei haft gaman að henni."
-    check_sentence(rc, s, [(4, 5, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(5, 5, "P_WRONG_PREP_AÐ")])
     #    s = "Ég sagði að ég hefði gaman að henni."  # Annotation variable depending on parse
     #    check_sentence(rc, s, [(5, 7, "P_WRONG_PREP_AÐ")])
     s = "Þau voru sérstaklega valin að stjórninni."
-    check_sentence(rc, s, [(1, 5, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AÐ")])
     #    s = "Þú ert valinn að guði að okkar mati."  # Annotation variable depending on parse
     #    check_sentence(rc, s, [(1, 7, "P_WRONG_PREP_AÐ")])
     s = "Það er til mjög lítið að mjólk."
-    check_sentence(rc, s, [(1, 6, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(5, 5, "P_WRONG_PREP_AÐ")])
     s = "Ekki er mikið til að mjólk."
-    check_sentence(rc, s, [(1, 5, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AÐ")])
     s = "Að öllu leyti er til fullt að mjólk."
-    check_sentence(rc, s, [(1, 5, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(4, 4, "P_WRONG_PREP_AÐ")])
     s = "Ég hef ekki unnið verkefni að þessu tagi."
-    check_sentence(rc, s, [(5, 7, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(5, 5, "P_WRONG_PREP_AÐ")])
     s = "Verkefni að þessum toga eru erfið."
-    check_sentence(rc, s, [(1, 3, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(1, 1, "P_WRONG_PREP_AÐ")])
     s = "Að mínu mati gerði ég þetta að krafti."
-    check_sentence(rc, s, [(6, 7, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(6, 6, "P_WRONG_PREP_AÐ")])
     s = "Hann gerði það að sjálfsdáðum."
     check_sentence(rc, s, [(3, 4, "P_aðaf")])
     s = "Að sjálfsögðu gerði ég þetta að sjálfsdáðum."
     check_sentence(rc, s, [(4, 5, "P_aðaf")])
     s = "Hún hefur ekki gert þetta að miklum krafti."
-    check_sentence(rc, s, [(5, 7, "P_WRONG_PREP_AÐ")])
+    check_sentence(rc, s, [(5, 5, "P_WRONG_PREP_AÐ")])
 
 
 def test_placename_pp(rc):


### PR DESCRIPTION
* Easy/important issues from media analysis fixed
* Latest version of Ritmyndir added
* 'í takti við' removed as an error, no basis in The Standards can be found
* Capitalized words are no longer marked as errors unless the suggested value is also capitalized
* Certain common words are now excluded from the taboo vocabulary, such as 'nýbúinn' (very common with another meaning) and hommi (should not be marked as a taboo word)
* Capitalized adjectives are still marked as an error, but only with the option `suppress_suggestions` set to False. These are in many cases a part of named entities (Danska ríkisútvarpið, Íslensk erfðagreining), but are also common as errors.
* Spans for af/að errors limited to the word that is changed. The same goes for the suggest value.