### PR TITLE
Functionality for preserving newline in corrected output implemented

### DIFF
--- a/src/reynir_correct/tools/diffchecker.py
+++ b/src/reynir_correct/tools/diffchecker.py
@@ -42,7 +42,9 @@ def gen(f: Iterator[str]) -> Iterable[str]:
 def main() -> None:
 
     options: Dict[str, Union[str, bool, Set[str]]] = {}
-    options["format"] = "text"  # text, json, csv, m2
+    options[
+        "format"
+    ] = "preservenewline"  # text, textplustoks, preservenewline, json, csv, m2
     options["annotations"] = True
     options["all_errors"] = True
     # options["input"] = open("prufa.txt", "r")
@@ -64,6 +66,7 @@ def main() -> None:
         # Nothing we can do
         print("No input has been given, nothing can be returned")
         sys.exit(1)
+    """
     itering = gen(infile)
     for sent in itering:
         sent = sent.strip()
@@ -89,7 +92,6 @@ def main() -> None:
     if x:
         print(x)
     print("=================================")
-    """
 
 
 if __name__ == "__main__":

--- a/src/reynir_correct/wrappers.py
+++ b/src/reynir_correct/wrappers.py
@@ -466,7 +466,7 @@ def check_grammar(**options: Any) -> str:
             accumul.append(txt)
         elif format == "preservenewline":
             arev = sorted(a, key=lambda ann: (ann.start, ann.end), reverse=True)
-            cleantoklist: List[CorrectToken] = toklist[:]
+            cleantoklist = toklist[:]
             for xann in arev:
                 if xann.suggest is None:
                     # Nothing to correct with, nothing we can do


### PR DESCRIPTION
* Option `preservenewline` added to wrappers.py.
* If newline is found in original text, it is added to the corrected text. 
* Example code added in diffchecker.py, see '# Used when output shouldn't be split into sentences'