### PR TITLE
Change minimum required python version to 3.7 (from 3.6)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy-3.6]
+        python-version: [3.7, 3.8, 3.9, pypy-3.7]
 
     steps:
     - uses: actions/checkout@v2
@@ -32,8 +32,8 @@ jobs:
         python -m pip install -e .
     - name: Type check with mypy
       run: |
-        if [ "${{ matrix.python-version }}" == "3.6" ]; then python -m pip install mypy; fi
-        if [ "${{ matrix.python-version }}" == "3.6" ]; then mypy --python-version=3.6 src/reynir_correct; fi
+        if [ "${{ matrix.python-version }}" == "3.7" ]; then python -m pip install mypy; fi
+        if [ "${{ matrix.python-version }}" == "3.7" ]; then mypy --python-version=3.7 src/reynir_correct; fi
     - name: Test with pytest
       run: |
         python -m pip install pytest

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 
 .. image:: https://img.shields.io/badge/License-MIT-yellow.svg
     :target: https://opensource.org/licenses/MIT
-.. image:: https://img.shields.io/badge/python-3.6-blue.svg
-    :target: https://www.python.org/downloads/release/python-360/
+.. image:: https://img.shields.io/badge/python-3.7-blue.svg
+    :target: https://www.python.org/downloads/release/python-370/
 .. image:: https://github.com/mideind/GreynirCorrect/workflows/Python%20package/badge.svg?branch=master
     :target: https://github.com/mideind/GreynirCorrect/actions?query=workflow%3A%22Python+package%22
 
@@ -14,7 +14,7 @@ GreynirCorrect: Spelling and grammar correction for Icelandic
 Overview
 ********
 
-**GreynirCorrect** is a Python 3 (>= 3.6) package and command line tool for
+**GreynirCorrect** is a Python 3 (>= 3.7) package and command line tool for
 **checking and correcting spelling and grammar** in Icelandic text.
 
 GreynirCorrect relies on the `Greynir <https://pypi.org/project/reynir/>`__ package,
@@ -175,7 +175,7 @@ An overview of error codes is available `here <https://github.com/mideind/Greyni
 Prerequisites
 *************
 
-GreynirCorrect runs on CPython 3.6 or newer, and on PyPy 3.6 or newer. It has
+GreynirCorrect runs on CPython 3.7 or newer, and on PyPy 3.7 or newer. It has
 been tested on Linux, macOS and Windows. The
 `PyPi package <https://pypi.org/project/reynir-correct/>`_
 includes binary wheels for common environments, but if the setup on your OS
@@ -191,7 +191,7 @@ requires compilation from sources, you may need
 Installation
 ************
 
-To install this package (assuming you have Python >= 3.6 with ``pip`` installed):
+To install this package (assuming you have Python >= 3.7 with ``pip`` installed):
 
 .. code-block:: bash
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -6,7 +6,7 @@ Installation
 Prerequisites
 -------------
 
-GreynirCorrect runs on **CPython 3.6** or newer, and on **PyPy 3.6**
+GreynirCorrect runs on **CPython 3.7** or newer, and on **PyPy 3.7**
 or newer (more info on PyPy `here <http://pypy.org/>`_).
 
 On GNU/Linux and similar systems, you may need to have ``python3-dev``

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@
     This module sets up the GreynirCorrect package and installs the
     'correct' command-line utility.
 
-    This package requires Python >= 3.6, and supports PyPy >= 3.6.
+    This package requires Python >= 3.7, and supports PyPy >= 3.7.
 
 """
 
@@ -51,8 +51,8 @@ from setuptools import find_packages  # type: ignore
 from setuptools import setup  # type: ignore
 
 
-if sys.version_info < (3, 6):
-    print("GreynirCorrect requires Python >= 3.6")
+if sys.version_info < (3, 7):
+    print("GreynirCorrect requires Python >= 3.7")
     sys.exit(1)
 
 
@@ -103,7 +103,6 @@ setup(
         "Natural Language :: Icelandic",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Python 3.6 has been out of support since Dec 2021.

The neural grammar correction project has dependencies that require python 3.7 at minimum (torch in particular).