### PR TITLE
Missing yield added

### DIFF
--- a/src/reynir_correct/errtokenizer.py
+++ b/src/reynir_correct/errtokenizer.py
@@ -2164,6 +2164,8 @@ def lookup_unknown_words(
                     yield rtok
                     context = (prev_context + tuple(rtok.txt.split()))[-3:]
                     prev_context = context
+            else:
+                yield token
             continue
 
         # And Icelandic Search Query Errors


### PR DESCRIPTION
* Token text got deleted when error category S001 was not activated. This has been fixed.