### PR TITLE
Add cardinals to allowed_multiples in config.

### DIFF
--- a/src/reynir_correct/config/GreynirCorrect.conf
+++ b/src/reynir_correct/config/GreynirCorrect.conf
@@ -2748,6 +2748,7 @@ eigi
 eigum
 einn
 eins
+eitt
 er
 fá
 falla
@@ -2757,6 +2758,7 @@ festi
 fimm
 finnur
 fjórir
+fjögur
 flæði
 flokkar
 formið
@@ -2854,6 +2856,7 @@ talið
 til
 tíma
 tveir
+tvö
 um
 undan
 undir
@@ -2883,6 +2886,7 @@ yrði
 þegar
 þjóna
 þrír
+þrjú
 
 
 [wrong_compounds]


### PR DESCRIPTION
This package handles phone numbers that are written out and sports scores in an unexpected way. 

Example:
```
Upphaflegur texti: 'Neyðarnúmerið er einn einn tveir.
Staðan var fimm fimm í hálfleik.

Setning:
Neyðarnúmerið er einn tveir .

Niðurstaða tókunar:
000 Neyðarnúmerið
001 er
002 einn tveir
003 .

Setningatré:
S0 S-MAIN IP NP-SUBJ no_et_nf_hk /NP-SUBJ VP VP so_1_nf_et_p3 /VP NP-PRD töl_ft_nf_kvk töl_ft_nf_kvk /NP-PRD /VP /IP /S-MAIN p /S0

Villur:
002-002: S005   Rita á 'einn einn tveir' sem 'einn tveir' | 'einn tveir' -> 'einn tveir' | None

Setning:
Staðan var fimm í hálfleik .

Niðurstaða tókunar:
000 Staðan
001 var
002 fimm
003 í
004 hálfleik
005 .

Setningatré:
S0 S-MAIN IP NP-SUBJ no_et_nf_kvk /NP-SUBJ VP VP so_1_nf_et_p3 /VP NP-PRD töl_ft_nf_hk PP P fs_þf /P NP no_et_þf_kk /NP /PP /NP
-PRD /VP /IP /S-MAIN p /S0

Villur:
002-002: C001   Endurtekið orð ('fimm') ætti að fella burt | 'fimm fimm' -> 'fimm' | None
```

Adding cardinal numbers (0-9) to allowed_multiples fixes this issue.