### PR TITLE
Updated CI config

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,28 +15,28 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "pypy-3.9", "pypy-3.10"]
+        python-version: [ "3.10", "3.11", "3.12", "pypy-3.9", "pypy-3.10"]
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install GreynirCorrect
       run: |
-        python -m pip install --upgrade pip wheel setuptools pytest
-        python -m pip install tokenizer reynir
+        python -m pip install uv
+        uv pip install --system --upgrade pip wheel setuptools pytest tokenizer reynir
         # No need to test the sentence classifier in every build (also doesn't work with PyPy)
-        if [ "${{ matrix.python-version }}" == "3.9" ]; then
-          python -m pip install -e ".[sentence_classifier]"
+        if [ "${{ matrix.python-version }}" == "3.10" ]; then
+          uv pip install --system -e ".[sentence_classifier]"
         else
-          python -m pip install -e ".[dev]"
+          uv pip install --system -e ".[dev]"
         fi
     - name: Typecheck with mypy
       run: |
-        if [ "${{ matrix.python-version }}" == "3.9" ]; then python -m pip install mypy; fi
-        if [ "${{ matrix.python-version }}" == "3.9" ]; then mypy --ignore-missing-imports --python-version=3.9 src/reynir_correct; fi
+        if [ "${{ matrix.python-version }}" == "3.10" ]; then python -m pip install mypy; fi
+        if [ "${{ matrix.python-version }}" == "3.10" ]; then mypy --ignore-missing-imports --python-version=3.9 src/reynir_correct; fi
     - name: Test with pytest
       run: |
         python -m pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ "3.10", "3.11", "3.12", "pypy-3.9", "pypy-3.10"]
+        python-version: [ "3.9", "3.13", "pypy-3.9", "pypy-3.10"]
 
     steps:
     - uses: actions/checkout@v4
@@ -26,17 +26,17 @@ jobs:
     - name: Install GreynirCorrect
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade pip wheel setuptools pytest tokenizer reynir
+        uv pip install --system --upgrade wheel setuptools pytest tokenizer reynir
         # No need to test the sentence classifier in every build (also doesn't work with PyPy)
-        if [ "${{ matrix.python-version }}" == "3.10" ]; then
+        if [ "${{ matrix.python-version }}" == "3.9" ]; then
           uv pip install --system -e ".[sentence_classifier]"
         else
           uv pip install --system -e ".[dev]"
         fi
     - name: Typecheck with mypy
       run: |
-        if [ "${{ matrix.python-version }}" == "3.10" ]; then python -m pip install mypy; fi
-        if [ "${{ matrix.python-version }}" == "3.10" ]; then mypy --ignore-missing-imports --python-version=3.9 src/reynir_correct; fi
+        if [ "${{ matrix.python-version }}" == "3.9" ]; then python -m pip install mypy; fi
+        if [ "${{ matrix.python-version }}" == "3.9" ]; then mypy --ignore-missing-imports --python-version=3.9 src/reynir_correct; fi
     - name: Test with pytest
       run: |
         python -m pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
* Only testing on CPython 3.9 and 3.13
* Explicitly supporting 3.13 in metadata
* Added testing on PyPy 3.10 (latest)
* Using `uv` for much faster CI runs